### PR TITLE
Added mail generator and verification function.

### DIFF
--- a/components/rootmail.yaml
+++ b/components/rootmail.yaml
@@ -25,6 +25,9 @@ Outputs:
   DelegationTarget:
     Description: Nameservers for the hosted zone delegation
     Value: !Join [ ',', !GetAtt HostedZone.NameServers ]
+  EmailGeneratorFunction:
+    Description: Lambda function to verify email delegation and generate new email aliases
+    Value: !Ref EmailGeneratorFunction
 
 Resources:
 
@@ -68,6 +71,130 @@ Resources:
             }
           ]
         }
+
+  EmailGeneratorFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: index.handler
+      InlineCode: !Sub |
+        import boto3
+        import itertools
+        import json
+        import time
+        import uuid
+
+        domain = "${Subdomain}.${Domain}"
+        ses = boto3.client("ses")
+
+        def backoff(msg, res, n):
+
+          wait = pow(2, n)
+
+          log({
+            'level': 'info',
+            'msg': msg,
+            'res': res,
+            'round': n,
+            'waiting_in_seconds': wait,
+          })
+
+          time.sleep(n)
+
+        def handler(event, context):
+
+          log({
+            'event': event,
+          })
+
+          verify = event.get('verify', 'true')
+
+          if verify == 'true':
+
+            for n in itertools.count(start=1):
+
+              res = ses.get_account_sending_enabled()
+
+              if res.get('Enabled'):
+                break
+              else:
+                backoff('sending not yet enabled', res, n)
+
+            for n in itertools.count(start=1):
+
+              res = ses.get_identity_verification_attributes(
+                Identities=[
+                  domain,
+                ],
+              )
+
+              if res.get('VerificationAttributes', {}).get(domain, {}).get('VerificationStatus') == 'Success':
+                break
+              else:
+                backoff('verification not yet successful', res, n)
+
+            for n in itertools.count(start=1):
+
+              res = ses.get_identity_dkim_attributes(
+                Identities=[
+                  domain,
+                ],
+              )
+
+              if res.get('DkimAttributes', {}).get(domain, {}).get('DkimVerificationStatus') == 'Success':
+                break
+              else:
+                backoff('DKIM verification not yet successful', res, n)
+
+            for n in itertools.count(start=1):
+
+              res = ses.get_identity_notification_attributes(
+                Identities=[
+                  domain,
+                ],
+              )
+
+              if res.get('NotificationAttributes', {}).get(domain, {}).get('ForwardingEnabled') == True:
+                break
+              else:
+                backoff('forwarding not yet enabled', res, n)
+
+          email = event.get('default')
+
+          if not email:
+
+            max = 64 - len(domain) - 1 - 5
+
+            alias = str(uuid.uuid4())
+            alias = alias[:max] * (len(alias) > max)
+
+            if len(alias) < 36:
+
+              log({
+                'domain': domain,
+                'msg': 'UUID local part was reduced in length because your domain is too long for Control Tower (64 characters in total) - this increases the chance of collisions',
+                'level': 'warn',
+                'length': len(alias),
+                'max': 36,
+              })
+
+            email = 'root+{alias}@{domain}'.format(alias = alias, domain = domain)
+
+          return {
+            'email': email,
+          }
+
+        def log(msg):
+          print(json.dumps(msg), flush=True)
+
+      Runtime: python3.7
+      Policies:
+        - Version: 2012-10-17
+          Statement:
+            - Effect: Allow
+              Action: # TODO: least privilege
+                - ses:*
+              Resource: "*"
+      Timeout: 260 # the timeout effectivly limits retries to 2^(n+1) - 1 = 9 attempts with backup
 
   HostedZone:
     Type: AWS::Route53::HostedZone

--- a/components/rootmail.yaml
+++ b/components/rootmail.yaml
@@ -104,6 +104,7 @@ Resources:
 
           log({
             'event': event,
+            'level': 'debug',
           })
 
           verify = event.get('verify', 'true')
@@ -497,54 +498,91 @@ Resources:
         import hashlib
         import json
 
-        s3 = boto3.client("s3")
-        ssm = boto3.client("ssm")
+        s3 = boto3.client('s3')
+        ssm = boto3.client('ssm')
 
         def handler(event, context):
 
-            # TODO: logging, error handling, spam/dkim/spf/av handling
+            log({
+              'event': event,
+              'level': 'debug',
+            })
 
-            id = event["Records"][0]["ses"]["mail"]["messageId"]
-            key = "RootEmails/{key}".format(key=id)
+            for record in event['Records']:
 
-            response = s3.get_object(
-              Bucket="${DomainBucket}",
-              Key=key,
-            )
+              id = record['ses']['mail']['messageId']
+              key = 'RootEmails/{key}'.format(key=id)
+              receipt = record['ses']['receipt']
 
-            msg = email.message_from_bytes(response["Body"].read(), policy=policy.default)
+              log({
+                'id': id,
+                'level': 'debug',
+                'key': key,
+                'msg': 'processing mail',
+              })
 
-            title=msg["subject"]
-            title=title[:1020] + " ..." * (len(title) > 1020)
+              verdicts = {
+                'dkim': receipt['dkimVerdict']['status'],
+                'spam': receipt['spamVerdict']['status'],
+                'spf': receipt['spfVerdict']['status'],
+                'virus': receipt['virusVerdict']['status'],
+              }
 
-            description=msg.get_body("plain").get_content()
-            description=description[:1020] + " ..." * (len(description) > 1020)
+              for k, v in verdicts.items():
 
-            source=recipient=event["Records"][0]["ses"]["mail"]["destination"][0]
-            source=source[:60] + ' ...' * (len(source) > 60)
+                if not v == 'PASS':
 
-            operational_data={
-              "/aws/dedup":{
-                "Value":json.dumps(
-                  {
-                    "dedupString":id,
-                  }
-                ),
-                "Type":"SearchableString",
-              },
-              "/aws/resources":{
-                "Value":json.dumps([
-                  {
-                    "arn":"arn:aws:s3:::${DomainBucket.Arn}/{key}".format(key=key),
-                  }
-                ]),
-                "Type":"SearchableString",
-              },
-            }
+                  log({
+                    'class': k,
+                    'id': id,
+                    'key': key,
+                    'level': 'warn',
+                    'msg': 'verdict failed - ops santa item skipped',
+                  })
 
-            ssm.create_ops_item(
-              Description=description,
-              OperationalData=operational_data,
-              Source=source,
-              Title=title,
-            )
+                  return
+
+              response = s3.get_object(
+                Bucket="${DomainBucket}",
+                Key=key,
+              )
+
+              msg = email.message_from_bytes(response["Body"].read(), policy=policy.default)
+
+              title=msg["subject"]
+              title=title[:1020] + " ..." * (len(title) > 1020)
+
+              description=msg.get_body("plain").get_content()
+              description=description[:1020] + " ..." * (len(description) > 1020)
+
+              source=recipient=event["Records"][0]["ses"]["mail"]["destination"][0]
+              source=source[:60] + ' ...' * (len(source) > 60)
+
+              operational_data={
+                "/aws/dedup":{
+                  "Value":json.dumps(
+                    {
+                      "dedupString":id,
+                    }
+                  ),
+                  "Type":"SearchableString",
+                },
+                "/aws/resources":{
+                  "Value":json.dumps([
+                    {
+                      "arn":"arn:aws:s3:::${DomainBucket.Arn}/{key}".format(key=key),
+                    }
+                  ]),
+                  "Type":"SearchableString",
+                },
+              }
+
+              ssm.create_ops_item(
+                Description=description,
+                OperationalData=operational_data,
+                Source=source,
+                Title=title,
+              )
+
+        def log(msg):
+          print(json.dumps(msg), flush=True)

--- a/tests/pipeline.yaml
+++ b/tests/pipeline.yaml
@@ -354,7 +354,7 @@ Resources:
               commands:
                 - cd tests
                 - pip3 install -r requirements.txt
-                - python3 -munittest tests.py
+                - python3 -munittest rootemails.py tests.py
 
   TestRole:
     Type: AWS::IAM::Role

--- a/tests/rootemails.py
+++ b/tests/rootemails.py
@@ -1,0 +1,146 @@
+import os
+import unittest
+import boto3
+import uuid
+import time
+
+# TODO: adopt this to work in other regions as well
+ses = boto3.client('ses', region_name='eu-west-1')
+ssm = boto3.client('ssm', region_name='eu-west-1')
+
+class RootemailsTestCase(unittest.TestCase):
+
+    @classmethod
+    def send_email(cls, id, body):
+
+        res = ses.list_identities(
+            IdentityType='Domain',
+            MaxItems=1,
+        )
+
+        domain = res['Identities'][0]
+
+        res = ses.send_email(
+            Source="test@{domain}".format(domain=domain),
+            Destination={
+                'ToAddresses': [
+                    "root+{id}@{domain}".format(domain=domain, id=id),
+                ],
+            },
+            Message={
+                'Subject': {
+                    'Data': id,
+                },
+                'Body': {
+                    'Text': {
+                        'Data': body,
+                    },
+                },
+            },
+        )
+
+        return res
+
+    def test_root_email(self):
+
+        id = uuid.uuid4().hex
+        self.send_email(id, 'This is a mail body')
+
+        time.sleep(10)
+
+        res = ssm.describe_ops_items(
+            OpsItemFilters=[
+                {
+                    'Key': 'Title',
+                    'Values': [
+                        "'{id}'".format(id=id[:18]), # ops center filters don't like contains with longer targets
+
+                    ],
+                    'Operator': 'Contains',
+                },
+                {
+                    'Key': 'Status',
+                    'Values': [
+                        'Open',
+                    ],
+                    'Operator': 'Equal',
+                },
+            ],
+        )
+
+        self.assertEqual(1, len(res.get('OpsItemSummaries', [])))
+
+        id = res['OpsItemSummaries'][0]['OpsItemId']
+
+        res = ssm.get_ops_item(
+            OpsItemId=id,
+        )
+
+        self.assertEqual('This is a mail body', res['OpsItem']['Description'].rstrip())
+
+        ssm.update_ops_item(
+            OpsItemId=id,
+            Status='Resolved',
+        )
+
+    def test_root_email_spam(self):
+
+        GTUBE='XJS*C4JDBQADN1.NSBN3*2IDNEN*GTUBE-STANDARD-ANTI-UBE-TEST-EMAIL*C.34X'
+
+        id = uuid.uuid4().hex
+        self.send_email(id, GTUBE)
+
+        time.sleep(10)
+
+        res = ssm.describe_ops_items(
+            OpsItemFilters=[
+                {
+                    'Key': 'Title',
+                    'Values': [
+                        "'{id}'".format(id=id[:18]), # ops center filters don't like contains with longer targets
+
+                    ],
+                    'Operator': 'Contains',
+                },
+                {
+                    'Key': 'Status',
+                    'Values': [
+                        'Open',
+                    ],
+                    'Operator': 'Equal',
+                },
+            ],
+        )
+
+        self.assertEqual(0, len(res.get('OpsItemSummaries', [])))
+
+    def test_root_email_virus(self):
+
+        EICAR='X5O!P%@AP[4\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*'
+
+        id = uuid.uuid4().hex
+        self.send_email(id, EICAR)
+
+        time.sleep(10)
+
+        res = ssm.describe_ops_items(
+            OpsItemFilters=[
+                {
+                    'Key': 'Title',
+                    'Values': [
+                        "'{id}'".format(id=id[:18]), # ops center filters don't like contains with longer targets
+
+                    ],
+                    'Operator': 'Contains',
+                },
+                {
+                    'Key': 'Status',
+                    'Values': [
+                        'Open',
+                    ],
+                    'Operator': 'Equal',
+                },
+            ],
+        )
+
+        self.assertEqual(0, len(res.get('OpsItemSummaries', [])))


### PR DESCRIPTION
## Definition of done (v0.0.1)

- [x] Automated integration test - will come later for the whole feature (see also [notes](https://github.com/superwerker/superwerker/issues/13#issuecomment-708531741) from #13)
- [X] Integrity protection - not needed
- [X] Structured Logging and Monitoring for Lambda - this is actually a proposal for some really simplistic logging; monitoring could be spiked here with X-Ray; wdyt?

The plan would be to reference the lambda output in the parent stack and either override the email (e.g. for existing CT setups in the CT stack) or let the function generate them. By default it also verifies (while doing exponential backoffs) that the email delegation setup works.

As a followup I'd delete the obsolete healthcheck.