### PR TITLE
allow multiple parallel test environments

### DIFF
--- a/components/superwerker.yaml
+++ b/components/superwerker.yaml
@@ -10,6 +10,8 @@ Parameters:
     Default: ""
   Domain:
     Type: String
+  Subdomain:
+    Type: String
   IncludeControlTower:
     AllowedValues:
       - true
@@ -161,6 +163,7 @@ Resources:
       TemplateURL: !Sub ${TemplateUrlPrefix}/components/rootmail.yaml
       Parameters:
         Domain: !Ref Domain
+        Subdomain: !Ref Subdomain
 
   SecurityHub:
     Condition: IncludeSecurityHub

--- a/tests/pipeline-dns-wiring.yaml
+++ b/tests/pipeline-dns-wiring.yaml
@@ -3,6 +3,8 @@ AWSTemplateFormatVersion: 2010-09-09
 Parameters:
   RootMailDomain:
     Type: String
+  RootMailSubdomain:
+    Type: String
 
   RootMailDelegationTarget:
     Type: CommaDelimitedList
@@ -13,7 +15,7 @@ Resources:
     Type: AWS::Route53::RecordSet
     Properties:
       HostedZoneName: !Sub ${RootMailDomain}.
-      Name: !Sub aws.${RootMailDomain}
+      Name: !Sub ${RootMailSubdomain}.${RootMailDomain}
       ResourceRecords: !Ref RootMailDelegationTarget
       TTL: 60
       Type: NS

--- a/tests/pipeline.yaml
+++ b/tests/pipeline.yaml
@@ -212,6 +212,7 @@ Resources:
 
                 # remove stacks
                 - aws cloudformation delete-stack --stack-name superwerker-pipeline-dns-wiring-${aws_account_id}
+                - aws --profile test_account cloudformation delete-stack --stack-name superwerker
 
   BuildAndTestProjectRole:
     Type: AWS::IAM::Role

--- a/tests/pipeline.yaml
+++ b/tests/pipeline.yaml
@@ -189,14 +189,14 @@ Resources:
                 - aws configure --profile test_account set credential_source EcsContainer
 
                 # setup superwerker in vended account
-                - aws --profile test_account cloudformation deploy --stack-name superwerker --template-file components/superwerker.yaml --parameter-overrides Domain=${ROOT_MAIL_DOMAIN} TemplateUrlPrefix=${TEMPLATE_URL_PREFIX} --capabilities CAPABILITY_AUTO_EXPAND CAPABILITY_IAM --no-fail-on-empty-changeset &
+                - aws --profile test_account cloudformation deploy --stack-name superwerker --template-file components/superwerker.yaml --parameter-overrides Domain=${ROOT_MAIL_DOMAIN} Subdomain=${aws_account_id} TemplateUrlPrefix=${TEMPLATE_URL_PREFIX} --capabilities CAPABILITY_AUTO_EXPAND CAPABILITY_IAM --no-fail-on-empty-changeset &
                 - while ! domain_name_servers=$(aws --profile test_account ssm get-parameter --name /superwerker/domain_name_servers --query Parameter.Value --output text); do sleep 10; done
-                - aws cloudformation deploy --stack-name superwerker-pipeline-dns-wiring --template-file tests/pipeline-dns-wiring.yaml --parameter-overrides RootMailDelegationTarget=$domain_name_servers RootMailDomain=${ROOT_MAIL_DOMAIN} --no-fail-on-empty-changeset
+                - aws cloudformation deploy --stack-name superwerker-pipeline-dns-wiring-${aws_account_id} --template-file tests/pipeline-dns-wiring.yaml --parameter-overrides RootMailDelegationTarget=$domain_name_servers RootMailDomain=${ROOT_MAIL_DOMAIN} RootMailSubdomain=${aws_account_id} --no-fail-on-empty-changeset
                 - sleep 3600 # give superwerker stack time to finish (Control Tower needs ~1h)
                 - aws --profile test_account cloudformation wait stack-create-complete --stack-name superwerker
 
                 - aws --profile test_account cloudformation deploy --stack-name superwerker-pipeline-account-factory-wiring --template-file tests/account-factory-wiring.yaml --parameter-overrides PipelineCloudformationRoleArn=$aws_cross_account_role_arn --capabilities CAPABILITY_AUTO_EXPAND CAPABILITY_IAM --no-fail-on-empty-changeset
-                - aws --profile test_account cloudformation deploy --stack-name superwerker-pipeline-account-factory-fixture --template-file tests/account-factory.yaml --parameter-overrides AccountName=sw-${aws_account_id} AccountEmail=root+${aws_account_id}@aws.${ROOT_MAIL_DOMAIN} SSOUserFirstName=Isolde SSOUserLastName=Mawidder-Baden SSOUserEmail=root+${aws_account_id}@aws.${ROOT_MAIL_DOMAIN} ManagedOrganizationalUnit=Custom --capabilities CAPABILITY_AUTO_EXPAND CAPABILITY_IAM --no-fail-on-empty-changeset
+                - aws --profile test_account cloudformation deploy --stack-name superwerker-pipeline-account-factory-fixture --template-file tests/account-factory.yaml --parameter-overrides AccountName=sw-${aws_account_id} AccountEmail=root+test@${aws_account_id}.${ROOT_MAIL_DOMAIN} SSOUserFirstName=Isolde SSOUserLastName=Mawidder-Baden SSOUserEmail=root+test@${aws_account_id}.${ROOT_MAIL_DOMAIN} ManagedOrganizationalUnit=Custom --capabilities CAPABILITY_AUTO_EXPAND CAPABILITY_IAM --no-fail-on-empty-changeset
 
                 - cd tests
                 - pip3 install -r requirements.txt
@@ -209,6 +209,9 @@ Resources:
                 # Node + ECS Container Creds + Assume Role doesn't seem to work, so work around by setting credentials
                 - eval $(aws sts assume-role --role-arn $aws_cross_account_role_arn --role-session-name test | jq -r '.Credentials | "export JS_AWS_ACCESS_KEY_ID=\(.AccessKeyId)\nexport JS_AWS_SECRET_ACCESS_KEY=\(.SecretAccessKey)\nexport JS_AWS_SESSION_TOKEN=\(.SessionToken)\n"')
                 - AWS_ACCESS_KEY_ID=$JS_AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY=$JS_AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN=$JS_AWS_SESSION_TOKEN CAPTCHA_KEY=$CAPTCHA_API_KEY node close-active-subaccounts.js
+
+                # remove stacks
+                - aws cloudformation delete-stack --stack-name superwerker-pipeline-dns-wiring-${aws_account_id}
 
   BuildAndTestProjectRole:
     Type: AWS::IAM::Role


### PR DESCRIPTION
by giving each run it's own subdomain (the vended aws account id)

this is another prerequisite for matrix tests as well

## Definition of done (v0.0.1)

- [x] Automated integration test
