### PR TITLE
fix: make rootmail stackset exec role only assumable from admin role

### DIFF
--- a/components/rootmail.yaml
+++ b/components/rootmail.yaml
@@ -740,7 +740,7 @@ Resources:
           - Effect: Allow
             Principal:
               AWS:
-                - !Sub "${AWS::AccountId}"
+                - !GetAtt StackSetAdministrationRole.Arn
             Action:
               - sts:AssumeRole
       Path: /


### PR DESCRIPTION
not the entire account

## Definition of done (v0.0.1)

- [x] Automated integration test
- [x] Integrity protection according to ADR-NNNN
- [x] Structured Logging and Monitoring for Lambda function according to ADR-NNNN
