### PR TITLE
Refresh AWS CLI credentials before running tests

### DIFF
--- a/tests/buildspec.yaml
+++ b/tests/buildspec.yaml
@@ -38,6 +38,7 @@ phases:
       - sleep 300 # give superwerker components some time to settle, e.g. SecurityHub member adding takes some minutes after account factory fixture has been rolled out
       - cd tests
       - pip3 install -r requirements.txt
+      - rm -rf ~/.aws/cli/cache # run tests with fresh credentials
       - AWS_REGION=${SUPERWERKER_REGION} AWS_DEFAULT_REGION=${SUPERWERKER_REGION} AWS_PROFILE=test_account ACCOUNT_FACTORY_ACCOUNT_ID=$(aws --profile test_account --region ${SUPERWERKER_REGION} cloudformation describe-stacks --stack-name superwerker-pipeline-account-factory-fixture --query "Stacks[0].Outputs[?OutputKey=='AccountId'].OutputValue" --output text) python3 -munittest rootemails.py tests.py
 
     finally:


### PR DESCRIPTION
to prevent "An error occurred (UnrecognizedClientException) when calling the DisableSecurityHub operation: The security token included in the request is invalid."