### PR TITLE
fix: unified rootmail wording

### DIFF
--- a/docs/adrs/rootmail.md
+++ b/docs/adrs/rootmail.md
@@ -1,4 +1,4 @@
-# Rootemail (_RML_)
+# Rootmail (_RML_)
 
 ## Context
 

--- a/docs/adrs/rootmail.md
+++ b/docs/adrs/rootmail.md
@@ -1,4 +1,4 @@
-# Rootmail (_RML_)
+# RootMail (_RML_)
 
 ## Context
 

--- a/templates/living-documentation.yaml
+++ b/templates/living-documentation.yaml
@@ -21,7 +21,7 @@ Resources:
                 - aws.cloudwatch
               detail:
                 alarmName:
-                  - superwerker-RootmailReady
+                  - superwerker-RootMailReady
 
       Handler: index.handler
       Policies:
@@ -60,7 +60,7 @@ Resources:
 
           rootmail_ready_alarm_state = cw.describe_alarms(
             AlarmNames=[
-                'superwerker-RootmailReady',
+                'superwerker-RootMailReady',
             ]
           )['MetricAlarms'][0]['StateValue']
 

--- a/templates/rootmail.yaml
+++ b/templates/rootmail.yaml
@@ -243,7 +243,7 @@ Resources:
       TTL: 60
       Type: TXT
 
-  RootmailReady:
+  RootMailReady:
     Type: AWS::Serverless::Function
     Properties:
       Events:
@@ -343,14 +343,14 @@ Resources:
               Resource: '*'
       Timeout: 260 # the timeout effectivly limits retries to 2^(n+1) - 1 = 9 attempts with backup
 
-  RootmailReadyAlert:
+  RootMailReadyAlert:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmName: superwerker-RootmailReady
+      AlarmName: superwerker-RootMailReady
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Dimensions:
         - Name: FunctionName
-          Value: !Ref RootmailReady
+          Value: !Ref RootMailReady
       EvaluationPeriods: 1
       MetricName: Errors
       Namespace: AWS/Lambda
@@ -358,16 +358,16 @@ Resources:
       Statistic: Sum
       Threshold: 1
 
-  RootmailReadyHandle:
+  RootMailReadyHandle:
     Type: AWS::CloudFormation::WaitConditionHandle
 
-  RootmailReadyHandleWaitCondition:
+  RootMailReadyHandleWaitCondition:
     Type: AWS::CloudFormation::WaitCondition
     Properties:
-      Handle: !Ref RootmailReadyHandle
+      Handle: !Ref RootMailReadyHandle
       Timeout: "28800" # 8 hours time to wire DNS
 
-  RootmailReadyTrigger:
+  RootMailReadyTrigger:
     Type: AWS::Serverless::Function
     Properties:
       Events:
@@ -381,14 +381,14 @@ Resources:
                 - aws.cloudwatch
               detail:
                 alarmName:
-                  - !Ref RootmailReadyAlert
+                  - !Ref RootMailReadyAlert
                 state:
                   value:
                     - OK
       Handler: index.handler
       Environment:
         Variables:
-          SIGNAL_URL: !Ref RootmailReadyHandle
+          SIGNAL_URL: !Ref RootMailReadyHandle
       InlineCode: |-
         import json
         import os
@@ -399,9 +399,9 @@ Resources:
 
           encoded_body = json.dumps({
               "Status": "SUCCESS",
-              "Reason": "Rootmail Setup completed",
+              "Reason": "RootMail Setup completed",
               "UniqueId": str(uuid.uuid4()),
-              "Data": "Rootmail Setup completed"
+              "Data": "RootMail Setup completed"
           })
 
           http = urllib3.PoolManager()

--- a/templates/rootmail.yaml
+++ b/templates/rootmail.yaml
@@ -47,7 +47,7 @@ Resources:
                 "Service": "ses.amazonaws.com"
               },
               "Resource": [
-                "arn:${AWS::Partition}:s3:::${EmailBucket}/RootMails/*"
+                "arn:${AWS::Partition}:s3:::${EmailBucket}/RootMail/*"
               ],
               "Sid": "EnableSESReceive"
             }
@@ -494,7 +494,7 @@ Resources:
                       print('LogicalResourceId: {}'.format(LogicalResourceId))
 
                       id = PhysicalResourceId
-                      rule_set_name = 'RootMails'
+                      rule_set_name = 'RootMail'
                       rule_name = 'Receive'
 
                       if RequestType == CREATE or RequestType == UPDATE:
@@ -516,7 +516,7 @@ Resources:
                                 {
                                   'S3Action'         : {
                                     'BucketName'     : '${EmailBucket}',
-                                    'ObjectKeyPrefix': 'RootMails'
+                                    'ObjectKeyPrefix': 'RootMail'
                                   },
                                 },
                                 {
@@ -578,7 +578,7 @@ Resources:
                     - Effect: Allow
                       Action:
                         - s3:GetObject
-                      Resource: ${EmailBucket.Arn}/RootMails/*
+                      Resource: ${EmailBucket.Arn}/RootMail/*
                     - Effect: Allow
                       Action:
                         - ssm:CreateOpsItem
@@ -622,7 +622,7 @@ Resources:
                       for record in event['Records']:
 
                         id = record['ses']['mail']['messageId']
-                        key = 'RootMails/{key}'.format(key=id)
+                        key = 'RootMail/{key}'.format(key=id)
                         receipt = record['ses']['receipt']
 
                         log({

--- a/templates/rootmail.yaml
+++ b/templates/rootmail.yaml
@@ -47,7 +47,7 @@ Resources:
                 "Service": "ses.amazonaws.com"
               },
               "Resource": [
-                "arn:${AWS::Partition}:s3:::${EmailBucket}/RootEmails/*"
+                "arn:${AWS::Partition}:s3:::${EmailBucket}/RootMails/*"
               ],
               "Sid": "EnableSESReceive"
             }
@@ -494,7 +494,7 @@ Resources:
                       print('LogicalResourceId: {}'.format(LogicalResourceId))
 
                       id = PhysicalResourceId
-                      rule_set_name = 'RootEmails'
+                      rule_set_name = 'RootMails'
                       rule_name = 'Receive'
 
                       if RequestType == CREATE or RequestType == UPDATE:
@@ -516,7 +516,7 @@ Resources:
                                 {
                                   'S3Action'         : {
                                     'BucketName'     : '${EmailBucket}',
-                                    'ObjectKeyPrefix': 'RootEmails'
+                                    'ObjectKeyPrefix': 'RootMails'
                                   },
                                 },
                                 {
@@ -578,7 +578,7 @@ Resources:
                     - Effect: Allow
                       Action:
                         - s3:GetObject
-                      Resource: ${EmailBucket.Arn}/RootEmails/*
+                      Resource: ${EmailBucket.Arn}/RootMails/*
                     - Effect: Allow
                       Action:
                         - ssm:CreateOpsItem
@@ -622,7 +622,7 @@ Resources:
                       for record in event['Records']:
 
                         id = record['ses']['mail']['messageId']
-                        key = 'RootEmails/{key}'.format(key=id)
+                        key = 'RootMails/{key}'.format(key=id)
                         receipt = record['ses']['receipt']
 
                         log({

--- a/templates/superwerker.template.yaml
+++ b/templates/superwerker.template.yaml
@@ -19,11 +19,11 @@ Parameters:
     ConstraintDescription: Account Email can contain only ASCII characters. This must be in the format of mail@example.com
   Domain:
     Type: String
-    Description: Domain used for Rootmail feature
+    Description: Domain used for RootMail feature
   Subdomain:
     Type: String
     Default: aws
-    Description: Sub domain used for Rootmail feature
+    Description: Sub domain used for RootMail feature
   IncludeBudget:
     AllowedValues:
       - 'Yes'

--- a/tests/buildspec.yaml
+++ b/tests/buildspec.yaml
@@ -39,7 +39,7 @@ phases:
       - cd tests
       - pip3 install -r requirements.txt
       - rm -rf ~/.aws/cli/cache # run tests with fresh credentials
-      - AWS_REGION=${SUPERWERKER_REGION} AWS_DEFAULT_REGION=${SUPERWERKER_REGION} AWS_PROFILE=test_account ACCOUNT_FACTORY_ACCOUNT_ID=$(aws --profile test_account --region ${SUPERWERKER_REGION} cloudformation describe-stacks --stack-name superwerker-pipeline-account-factory-fixture --query "Stacks[0].Outputs[?OutputKey=='AccountId'].OutputValue" --output text) python3 -munittest rootemails.py backup.py tests.py
+      - AWS_REGION=${SUPERWERKER_REGION} AWS_DEFAULT_REGION=${SUPERWERKER_REGION} AWS_PROFILE=test_account ACCOUNT_FACTORY_ACCOUNT_ID=$(aws --profile test_account --region ${SUPERWERKER_REGION} cloudformation describe-stacks --stack-name superwerker-pipeline-account-factory-fixture --query "Stacks[0].Outputs[?OutputKey=='AccountId'].OutputValue" --output text) python3 -munittest rootmails.py backup.py tests.py
 
     finally:
       # close sub-accounts so that the OVM can close the main / management account later

--- a/tests/buildspec.yaml
+++ b/tests/buildspec.yaml
@@ -39,7 +39,7 @@ phases:
       - cd tests
       - pip3 install -r requirements.txt
       - rm -rf ~/.aws/cli/cache # run tests with fresh credentials
-      - AWS_REGION=${SUPERWERKER_REGION} AWS_DEFAULT_REGION=${SUPERWERKER_REGION} AWS_PROFILE=test_account ACCOUNT_FACTORY_ACCOUNT_ID=$(aws --profile test_account --region ${SUPERWERKER_REGION} cloudformation describe-stacks --stack-name superwerker-pipeline-account-factory-fixture --query "Stacks[0].Outputs[?OutputKey=='AccountId'].OutputValue" --output text) python3 -munittest rootmails.py backup.py tests.py
+      - AWS_REGION=${SUPERWERKER_REGION} AWS_DEFAULT_REGION=${SUPERWERKER_REGION} AWS_PROFILE=test_account ACCOUNT_FACTORY_ACCOUNT_ID=$(aws --profile test_account --region ${SUPERWERKER_REGION} cloudformation describe-stacks --stack-name superwerker-pipeline-account-factory-fixture --query "Stacks[0].Outputs[?OutputKey=='AccountId'].OutputValue" --output text) python3 -munittest rootmail.py backup.py tests.py
 
     finally:
       # close sub-accounts so that the OVM can close the main / management account later

--- a/tests/rootmail.py
+++ b/tests/rootmail.py
@@ -7,7 +7,7 @@ import time
 ses = boto3.client('ses', region_name='eu-west-1')
 ssm = boto3.client('ssm')
 
-class RootmailsTestCase(unittest.TestCase):
+class RootmailTestCase(unittest.TestCase):
 
     @classmethod
     def send_email(cls, id, body_text=None, body_html=None, subject=None):

--- a/tests/rootmail.py
+++ b/tests/rootmail.py
@@ -7,7 +7,7 @@ import time
 ses = boto3.client('ses', region_name='eu-west-1')
 ssm = boto3.client('ssm')
 
-class RootmailTestCase(unittest.TestCase):
+class RootMailTestCase(unittest.TestCase):
 
     @classmethod
     def send_email(cls, id, body_text=None, body_html=None, subject=None):

--- a/tests/rootmails.py
+++ b/tests/rootmails.py
@@ -7,7 +7,7 @@ import time
 ses = boto3.client('ses', region_name='eu-west-1')
 ssm = boto3.client('ssm')
 
-class RootemailsTestCase(unittest.TestCase):
+class RootmailsTestCase(unittest.TestCase):
 
     @classmethod
     def send_email(cls, id, body_text=None, body_html=None, subject=None):


### PR DESCRIPTION
fixes #121

I decided to use "RootMail" because it was already used more often than any other variant.