### PR TITLE
fix(backup): depend on trigger/event instead of only the pure Lambda

### DIFF
--- a/templates/backup.yaml
+++ b/templates/backup.yaml
@@ -427,7 +427,7 @@ Resources:
 
   EnableCloudFormationStacksetsOrgAccess:
     Type: AWS::Synthetics::Canary
-    DependsOn: CfnStackSetsReady
+    DependsOn: CfnStackSetsReadyEnablePermission # make sure the Lambda which handles the wait condition is entirely ready before enabling Cloudformation Org access. This includes Lambda event+permission have to be ready.
     Metadata:
       cfn-lint:
         config:


### PR DESCRIPTION
since depending on the Lambda without trigger does not seem to be sufficient

hopefully fixes #145 

## Definition of done (v0.0.1)

- [x] Automated integration test
- [x] Integrity protection according to ADR-NNNN
- [x] Structured Logging and Monitoring for Lambda function according to ADR-NNNN
