### PR TITLE
fix(control-tower): fix control tower setup

### DIFF
--- a/templates/control-tower.yaml
+++ b/templates/control-tower.yaml
@@ -94,6 +94,13 @@ Resources:
 
               await page.goto(consoleLoginUrl, {waitUntil: ['load', 'networkidle0']});
 
+              // remove cookie banner if present
+              try {
+                page.waitForSelector('#awsccc-cb-buttons > button.awsccc-u-btn.awsccc-u-btn-primary');
+                await page.click('#awsccc-cb-buttons > button.awsccc-u-btn.awsccc-u-btn-primary');
+                await page.waitFor(1000);
+              } catch (e) {
+              }
             });
 
             await synthetics.executeStep('gotoCT', async function () {


### PR DESCRIPTION
by accepting the cookie banner if present. otherwise button would be overlapped by the cookie banner so pupeteers fails clicking through the setup process

fixes #162 