### PR TITLE
Add version information

### DIFF
--- a/templates/living-documentation.yaml
+++ b/templates/living-documentation.yaml
@@ -9,19 +9,6 @@ Parameters:
     Description: Name of the parent superwerker CloudFormation stack
 
 Resources:
-  DashboardVersionFunction:
-    Type: AWS::Serverless::Function
-    Properties:
-      Handler: index.handler
-      Runtime: python3.7
-      Timeout: 60
-      Environment:
-        Variables:
-          SUPERWERKER_STACK_NAME: !Ref SuperwerkerStackName
-      InlineCode: |
-        def handler(event, context):
-          return "Done"
-
   DashboardGeneratorFunction:
     Type: AWS::Serverless::Function
     Properties:
@@ -51,6 +38,9 @@ Resources:
             - Effect: Allow
               Action: cloudwatch:DescribeAlarms
               Resource: '*'
+            - Effect: Allow
+              Action: cloudformation:GetTemplateSummary
+              Resource: !Sub arn:{AWS::Partition}:cloudformation:{AWS::Region}:{AWS::AccountId}:stack/{SuperwerkerStackName}/*
       Environment:
         Variables:
           SUPERWERKER_DOMAIN: !Ref SuperwerkerDomain
@@ -59,11 +49,19 @@ Resources:
         import boto3
         import json
         import os
+        import urllib.request
+        import urllib.parse
+
         from datetime import datetime
 
         cw = boto3.client("cloudwatch")
         ssm = boto3.client("ssm")
 
+        def get_latest_version():
+          response = urllib.request.urlopen('https://api.github.com/repos/superwerker/superwerker/releases/latest').read()
+          data = json.loads(response.decode('utf-8'))
+          
+          return data['name']
 
         def get_current_version():
           response = cfn.get_template_summary(
@@ -74,6 +72,14 @@ Resources:
           
           return metadata['SuperwerkerVersion']
 
+        def get_version_label():
+          current = get_current_version()
+          release = get_latest_version()
+          
+          if current == release:
+              return "🛠 Version: {version} (No updates available)".format(version=current)
+          else:
+              return "🛠 Version: {version} ([{release} available on GitHub](https://github.com/superwerker/superwerker))".format(version=current, release=release)
 
         def handler(event, context):
 
@@ -96,17 +102,17 @@ Resources:
             dns_delegation_text = """
         #### 🏠 {domain}
         #### ✅ DNS configuration is set up correctly. 
-        #### 🛠 Version: {version}
+        #### {version}
         """.format(
           domain=os.environ['SUPERWERKER_DOMAIN'],
-          version=get_current_version(),
+          version=get_version_label(),
         )
           else:
             if '/superwerker/domain_name_servers' in superwerker_config:
               dns_delegation_text = """
         #### 🏠 {domain}
         #### ❌ DNS configuration needed. 
-        #### 🛠 Version: {version}
+        #### {version}
 
         &nbsp;
 
@@ -123,7 +129,7 @@ Resources:
         """.format(
           domain=os.environ['SUPERWERKER_DOMAIN'],
           ns=superwerker_config['/superwerker/domain_name_servers'].split(','),
-          version=get_current_version(),
+          version=get_version_label(),
         )
             else:
               dns_delegation_text = '### DNS Setup pending'

--- a/templates/living-documentation.yaml
+++ b/templates/living-documentation.yaml
@@ -55,6 +55,7 @@ Resources:
         from datetime import datetime
 
         cw = boto3.client("cloudwatch")
+        cfn = boto3.client("cloudformation")
         ssm = boto3.client("ssm")
 
         def get_latest_version():

--- a/templates/living-documentation.yaml
+++ b/templates/living-documentation.yaml
@@ -4,8 +4,21 @@ Transform: AWS::Serverless-2016-10-31
 Parameters:
   SuperwerkerDomain:
     Type: String
+  SuperwerkerStackName:
+    Type: String
+    Description: Name of the parent superwerker CloudFormation stack
 
 Resources:
+  DashboardVersionFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: index.handler
+      Environment:
+        Variables:
+          SUPERWERKER_STACK_NAME: !Ref SuperwerkerStackName
+      InlineCode: |
+        def handler(event, context):
+          return "Done"
 
   DashboardGeneratorFunction:
     Type: AWS::Serverless::Function

--- a/templates/living-documentation.yaml
+++ b/templates/living-documentation.yaml
@@ -54,6 +54,7 @@ Resources:
       Environment:
         Variables:
           SUPERWERKER_DOMAIN: !Ref SuperwerkerDomain
+          SUPERWERKER_STACK_NAME: !Ref SuperwerkerStackName
       InlineCode: |
         import boto3
         import json
@@ -62,6 +63,17 @@ Resources:
 
         cw = boto3.client("cloudwatch")
         ssm = boto3.client("ssm")
+
+
+        def get_current_version():
+          response = cfn.get_template_summary(
+              StackName=os.getenv('SUPERWERKER_STACK_NAME')
+          )
+          
+          metadata = json.loads(response['Metadata'])
+          
+          return metadata['SuperwerkerVersion']
+
 
         def handler(event, context):
 
@@ -84,14 +96,17 @@ Resources:
             dns_delegation_text = """
         #### 🏠 {domain}
         #### ✅ DNS configuration is set up correctly. 
+        #### 🛠 Version: {version}
         """.format(
           domain=os.environ['SUPERWERKER_DOMAIN'],
+          version=get_current_version(),
         )
           else:
             if '/superwerker/domain_name_servers' in superwerker_config:
               dns_delegation_text = """
         #### 🏠 {domain}
         #### ❌ DNS configuration needed. 
+        #### 🛠 Version: {version}
 
         &nbsp;
 
@@ -108,6 +123,7 @@ Resources:
         """.format(
           domain=os.environ['SUPERWERKER_DOMAIN'],
           ns=superwerker_config['/superwerker/domain_name_servers'].split(','),
+          version=get_current_version(),
         )
             else:
               dns_delegation_text = '### DNS Setup pending'

--- a/templates/living-documentation.yaml
+++ b/templates/living-documentation.yaml
@@ -13,6 +13,10 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Events:
+        DailyGeneration:
+          Type: Schedule
+          Properties:
+            Schedule: rate(1 day)
         EmailHealth:
           Type: CloudWatchEvent
           Properties:

--- a/templates/living-documentation.yaml
+++ b/templates/living-documentation.yaml
@@ -13,6 +13,8 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
+      Runtime: python3.7
+      Timeout: 60
       Environment:
         Variables:
           SUPERWERKER_STACK_NAME: !Ref SuperwerkerStackName
@@ -35,8 +37,9 @@ Resources:
               detail:
                 alarmName:
                   - superwerker-RootMailReady
-
       Handler: index.handler
+      Runtime: python3.7
+      Timeout: 60
       Policies:
         - SSMParameterReadPolicy:
             ParameterName: 'superwerker/*'
@@ -147,10 +150,6 @@ Resources:
 
         def log(msg):
           print(json.dumps(msg), flush=True)
-
-
-      Runtime: python3.7
-      Timeout: 60
 
 Metadata:
   SuperwerkerVersion: 0.0.0-DEVELOPMENT

--- a/templates/living-documentation.yaml
+++ b/templates/living-documentation.yaml
@@ -40,7 +40,7 @@ Resources:
               Resource: '*'
             - Effect: Allow
               Action: cloudformation:GetTemplateSummary
-              Resource: !Sub arn:{AWS::Partition}:cloudformation:{AWS::Region}:{AWS::AccountId}:stack/{SuperwerkerStackName}/*
+              Resource: !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/${SuperwerkerStackName}/*
       Environment:
         Variables:
           SUPERWERKER_DOMAIN: !Ref SuperwerkerDomain

--- a/templates/notifications.yaml
+++ b/templates/notifications.yaml
@@ -77,3 +77,6 @@ Resources:
 
         def log(msg):
           print(json.dumps(msg), flush=True)
+
+Metadata:
+  SuperwerkerVersion: 0.0.0-DEVELOPMENT

--- a/templates/superwerker.template.yaml
+++ b/templates/superwerker.template.yaml
@@ -275,6 +275,7 @@ Resources:
             S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
       Parameters:
         SuperwerkerDomain: !Sub '${Subdomain}.${Domain}'
+        SuperwerkerStackName: !Ref AWS::StackName
 
   RootMail:
     Type: AWS::CloudFormation::Stack


### PR DESCRIPTION
This PR adds information to the dashboard about the used superwerker version and if another/newer version is available on GitHub. To check this on a regular basis, the generator function for the dashboard is scheduled to be invoked daily.

Releated to #20 

### Screenshots

<img width="487" alt="Screenshot 2021-03-23 at 08 42 54" src="https://user-images.githubusercontent.com/248965/112111643-c32fdc80-8bb4-11eb-874d-c206667e9056.png">
<img width="488" alt="Screenshot 2021-03-23 at 08 41 54" src="https://user-images.githubusercontent.com/248965/112111644-c3c87300-8bb4-11eb-8e58-3ef50a7fdced.png">

### Implementation Details

- A new event is added to the generator function `rate(1 day)`
- The lambda function retrieves the root stack metadata to get the current version
- The lambda function retrieves the latest release from GitHub
- As the CloudFormation stack may not be named `superwerker`, the root stack passes its name as a parameter to the child stack