### PR TITLE
WIP: SAM package for getting rid of inline Lambdas and 4096 char limit

### DIFF
--- a/templates/Makefile
+++ b/templates/Makefile
@@ -1,0 +1,3 @@
+build-DashboardGeneratorFunction:
+	cd living-documentation/ && \
+	  cp *.py $(ARTIFACTS_DIR)

--- a/templates/living-documentation.yaml
+++ b/templates/living-documentation.yaml
@@ -4,11 +4,15 @@ Transform: AWS::Serverless-2016-10-31
 Parameters:
   SuperwerkerDomain:
     Type: String
+  AssetsS3Bucket:
+    Type: String
 
 Resources:
 
   DashboardGeneratorFunction:
     Type: AWS::Serverless::Function
+    Metadata:
+      BuildMethod: makefile
     Properties:
       Events:
         EmailHealth:
@@ -23,7 +27,7 @@ Resources:
                 alarmName:
                   - superwerker-RootMailReady
 
-      CodeUri: living-documentation/
+      CodeUri: !Sub s3://superwerker-releases-${AWS::Region}/sam-package-for-lambdas/living-documentation/dashboard.zip
       Handler: dashboard.handler
       Policies:
         - SSMParameterReadPolicy:
@@ -39,7 +43,7 @@ Resources:
       Environment:
         Variables:
           SUPERWERKER_DOMAIN: !Ref SuperwerkerDomain
-      Runtime: python3.7
+      Runtime: python3.8
       Timeout: 60
 
 Metadata:

--- a/templates/living-documentation.yaml
+++ b/templates/living-documentation.yaml
@@ -23,7 +23,8 @@ Resources:
                 alarmName:
                   - superwerker-RootMailReady
 
-      Handler: index.handler
+      CodeUri: living-documentation/
+      Handler: dashboard.handler
       Policies:
         - SSMParameterReadPolicy:
             ParameterName: 'superwerker/*'
@@ -38,104 +39,6 @@ Resources:
       Environment:
         Variables:
           SUPERWERKER_DOMAIN: !Ref SuperwerkerDomain
-      InlineCode: |
-        import boto3
-        import json
-        import os
-        from datetime import datetime
-
-        cw = boto3.client("cloudwatch")
-        ssm = boto3.client("ssm")
-
-        def handler(event, context):
-
-          superwerker_config = {}
-          for ssm_parameter in ssm.get_parameters(
-            Names=[
-              '/superwerker/domain_name_servers'
-            ]
-          )['Parameters']:
-            superwerker_config[ssm_parameter['Name']] = ssm_parameter['Value']
-
-
-          rootmail_ready_alarm_state = cw.describe_alarms(
-            AlarmNames=[
-                'superwerker-RootMailReady',
-            ]
-          )['MetricAlarms'][0]['StateValue']
-
-          if rootmail_ready_alarm_state == 'OK':
-            dns_delegation_text = """
-        #### 🏠 {domain}
-        #### ✅ DNS configuration is set up correctly. 
-        """.format(
-          domain=os.environ['SUPERWERKER_DOMAIN'],
-        )
-          else:
-            if '/superwerker/domain_name_servers' in superwerker_config:
-              dns_delegation_text = """
-        #### 🏠 {domain}
-        #### ❌ DNS configuration needed. 
-
-        &nbsp;
-
-        ### Next Steps 
-
-        Please create the following NS records for your domain:
-
-        ```
-        {ns[0]}
-        {ns[1]}
-        {ns[2]}
-        {ns[3]}
-        ```
-        """.format(
-          domain=os.environ['SUPERWERKER_DOMAIN'],
-          ns=superwerker_config['/superwerker/domain_name_servers'].split(','),
-        )
-            else:
-              dns_delegation_text = '### DNS Setup pending'
-
-          markdown = """
-        # [superwerker](https://github.com/superwerker/superwerker)
-        &nbsp;
-
-        {dns_delegation}
-
-        &nbsp;
-
-        ```
-        Updated at {current_time} (use browser reload to refresh)
-        ```
-          """.format(
-            dns_delegation=dns_delegation_text,
-            current_time=datetime.now(),
-          )
-
-          body = {
-            "widgets": [
-              {
-                "type": "text",
-                "x": 0,
-                "y": 0,
-                "width": 24,
-                "height": 20,
-                "properties": {
-                  "markdown": markdown,
-                }
-              }
-            ]
-          }
-
-          cw.put_dashboard(
-            DashboardName='superwerker',
-            DashboardBody=json.dumps(body),
-          )
-
-        def log(msg):
-          print(json.dumps(msg), flush=True)
-
-
       Runtime: python3.7
       Timeout: 60
 

--- a/templates/living-documentation/dashboard.py
+++ b/templates/living-documentation/dashboard.py
@@ -1,0 +1,95 @@
+import boto3
+import json
+import os
+from datetime import datetime
+
+cw = boto3.client("cloudwatch")
+ssm = boto3.client("ssm")
+
+def handler(event, context):
+
+    superwerker_config = {}
+    for ssm_parameter in ssm.get_parameters(
+            Names=[
+                '/superwerker/domain_name_servers'
+            ]
+    )['Parameters']:
+        superwerker_config[ssm_parameter['Name']] = ssm_parameter['Value']
+
+
+    rootmail_ready_alarm_state = cw.describe_alarms(
+        AlarmNames=[
+            'superwerker-RootMailReady',
+        ]
+    )['MetricAlarms'][0]['StateValue']
+
+    if rootmail_ready_alarm_state == 'OK':
+        dns_delegation_text = """
+        #### 🏠 {domain}
+        #### ✅ DNS configuration is set up correctly. 
+        """.format(
+            domain=os.environ['SUPERWERKER_DOMAIN'],
+        )
+    else:
+        if '/superwerker/domain_name_servers' in superwerker_config:
+            dns_delegation_text = """
+        #### 🏠 {domain}
+        #### ❌ DNS configuration needed. 
+
+        &nbsp;
+
+        ### Next Steps 
+
+        Please create the following NS records for your domain:
+
+        ```
+        {ns[0]}
+        {ns[1]}
+        {ns[2]}
+        {ns[3]}
+        ```
+        """.format(
+                domain=os.environ['SUPERWERKER_DOMAIN'],
+                ns=superwerker_config['/superwerker/domain_name_servers'].split(','),
+            )
+        else:
+            dns_delegation_text = '### DNS Setup pending'
+
+    markdown = """
+        # [superwerker](https://github.com/superwerker/superwerker)
+        &nbsp;
+
+        {dns_delegation}
+
+        &nbsp;
+
+        ```
+        Updated at {current_time} (use browser reload to refresh)
+        ```
+          """.format(
+        dns_delegation=dns_delegation_text,
+        current_time=datetime.now(),
+    )
+
+    body = {
+        "widgets": [
+            {
+                "type": "text",
+                "x": 0,
+                "y": 0,
+                "width": 24,
+                "height": 20,
+                "properties": {
+                    "markdown": markdown,
+                }
+            }
+        ]
+    }
+
+    cw.put_dashboard(
+        DashboardName='superwerker',
+        DashboardBody=json.dumps(body),
+    )
+
+def log(msg):
+    print(json.dumps(msg), flush=True)

--- a/templates/superwerker.yaml
+++ b/templates/superwerker.yaml
@@ -268,9 +268,14 @@ Resources:
   LivingDocumentation:
     Type: AWS::CloudFormation::Stack
     Properties:
-      TemplateURL: ./living-documentation.yaml
+      TemplateURL:
+        Fn::Sub:
+          - 'https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}templates/living-documentation.yaml'
+          - S3Region: !If [UsingDefaultBucket, !Sub '${AWS::Region}', !Ref QSS3BucketRegion]
+            S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
       Parameters:
         SuperwerkerDomain: !Sub '${Subdomain}.${Domain}'
+        AssetsS3Bucket: !Sub superwerker-deployment-${AWS::Region}
 
   RootMail:
     Type: AWS::CloudFormation::Stack

--- a/templates/superwerker.yaml
+++ b/templates/superwerker.yaml
@@ -268,11 +268,7 @@ Resources:
   LivingDocumentation:
     Type: AWS::CloudFormation::Stack
     Properties:
-      TemplateURL:
-        Fn::Sub:
-          - 'https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}templates/living-documentation.yaml'
-          - S3Region: !If [UsingDefaultBucket, !Sub '${AWS::Region}', !Ref QSS3BucketRegion]
-            S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
+      TemplateURL: ./living-documentation.yaml
       Parameters:
         SuperwerkerDomain: !Sub '${Subdomain}.${Domain}'
 

--- a/tests/update-test-env.sh
+++ b/tests/update-test-env.sh
@@ -15,4 +15,6 @@ template_prefix=${git_branch}/
 
 aws --profile ${SOURCE_PROFILE} s3 sync ../templates s3://superwerker-deployment/${git_branch}/templates
 
+aws --profile ${SOURCE_PROFILE} cloudformation package --template-file ../templates/superwerker.yaml --s3-bucket ${template_bucket_name} --s3-prefix ${template_prefix} --output-template-file ../templates/superwerker.template.yaml
+
 aws --profile test_account_${AWS_ACCOUNT_ID} --region ${superwerker_region} cloudformation deploy --stack-name superwerker --template-file ../templates/superwerker.template.yaml --parameter-overrides QSS3BucketName=${template_bucket_name} QSS3BucketRegion=${template_region} QSS3KeyPrefix=${template_prefix} --capabilities CAPABILITY_AUTO_EXPAND CAPABILITY_IAM --no-fail-on-empty-changeset


### PR DESCRIPTION
While developing #20 I was hitting the 4096 CFN inline Lambda limit so I thought it might be time to move away from inline Lambda code. This PR shows how to use `aws cloudformation package` and SAM to package the Lambda code (and other resources such as child CloudFormation stacks). 

Challenges:

 - create / maintain regional buckets (Lambda needs regional S3 buckets to load its code from) (see https://aws.amazon.com/blogs/infrastructure-and-automation/deploying-aws-lambda-functions-using-aws-cloudformation-the-portable-way/) 
 - [Bucket name squatting](https://onecloudplease.com/blog/s3-bucket-namesquatting) should be considered
 - `cloudformation package` has to be called for each regional bucket since it hardcodes the bucket name. This would probably not work with the current Quick Start since it has one static template 
 - We have to make sure the QuickStarts team is OK with the change

What is still missing:

 - make it work with multi-region
 - change the deployment pipeline to call `cloudformation package`
 - change the Github Actions pipeline to call `cloudformation package`
 - release process for the AWS Quickstart, since copying over files from this repo / cherry picking commits would not suffice anymore. https://github.com/superwerker/superwerker/discussions/180 would solve this

## Other approaches:

 - [Build a Lambda Layer not the fly](https://medium.com/nordcloud-engineering/pushing-the-limits-of-the-cfn-inline-lambda-to-the-max-f4a2ae3a9753)
 - See this discussion: https://github.com/superwerker/superwerker/discussions/192

## Definition of done (v0.0.1)

- [ ] Automated integration test
- [ ] Integrity protection according to ADR-NNNN
- [ ] Structured Logging and Monitoring for Lambda function according to ADR-NNNN
