### PR TITLE
make it possible to get feedback earlier than pushing to `main`

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,26 @@
+# Development
+
+## Prerequisites
+
+### MAVM (Management Account Vending Machine)
+
+TBD
+
+## Development
+
+TBD
+
+## Testing branches before merging to main
+
+superwerker provides a [CodeBuild job](tests/build.yaml) which can be used to test branches before merging changes to the `main` branch. The CodeBuild job uses the same test infrastructure as the pipeline, so it should be pretty safe to merge a branch after a successful CodeBuild job run.
+
+This can also be seen as preparation for [PR tests](https://github.com/superwerker/superwerker/issues/136).
+
+### Usage
+
+1. Deploy the [CodeBuild CloudFormation template](tests/build.yaml)
+2. Run the build
+```shell
+cd tests
+CODEBUILD_PROJECT_NAME=<codebuild_project_name_from_above_cloudformation_stack> SOURCE_PROFILE=<source_profile> ./start-build.sh
+```

--- a/tests/build.yaml
+++ b/tests/build.yaml
@@ -1,0 +1,56 @@
+AWSTemplateFormatVersion: 2010-09-09
+Transform: AWS::Serverless-2016-10-31
+
+Parameters:
+  OrganizationsVendingMachineEndpoint:
+    Type: String
+  RootMailDomain:
+    Type: String
+  DeploymentBucket:
+    Type: String
+    Default: superwerker-deployment
+
+Resources:
+
+  BuildAndTestProject:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      TimeoutInMinutes: 180
+      Environment:
+        ComputeType: BUILD_GENERAL1_SMALL
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
+        Type: LINUX_CONTAINER
+        EnvironmentVariables:
+          - Name: ROOT_MAIL_DOMAIN
+            Value: !Ref RootMailDomain
+          - Name: ORGANIZATIONS_VENDING_MACHINE_ENDPOINT
+            Value: !Ref OrganizationsVendingMachineEndpoint
+          - Name: CAPTCHA_API_KEY
+            Value: /superwerker/tests/2captcha_api_key
+            Type: SECRETS_MANAGER
+          - Name: TEMPLATE_BUCKET_NAME
+            Value: !Ref DeploymentBucket
+          - Name: TEMPLATE_REGION
+            Value: !Ref AWS::Region
+
+      ServiceRole: !GetAtt BuildAndTestProjectRole.Arn
+      Artifacts:
+        Type: NO_ARTIFACTS
+      Source:
+        Type: GITHUB
+        Location: https://github.com/superwerker/superwerker.git
+        BuildSpec: tests/buildspec.yaml
+
+  BuildAndTestProjectRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          Effect: Allow
+          Principal:
+            Service:
+              - codebuild.amazonaws.com
+          Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AdministratorAccess # FIXME: least privilege

--- a/tests/start-build.sh
+++ b/tests/start-build.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -euo pipefail
+
+superwerker_region=${SUPERWERKER_REGION:-"eu-central-1"}
+git_branch=$(git branch --show-current)
+
+echo Source Profile ${SOURCE_PROFILE} - Region ${superwerker_region} - Branch ${git_branch} - CodeBuild Project Name ${CODEBUILD_PROJECT_NAME}
+
+template_prefix=${git_branch}/
+
+aws --profile ${SOURCE_PROFILE} --no-cli-pager codebuild start-build \
+  --project-name ${CODEBUILD_PROJECT_NAME} \
+  --environment-variables-override name=TEMPLATE_PREFIX,value=${template_prefix} name=SUPERWERKER_REGION,value=${superwerker_region}


### PR DESCRIPTION
by providing a codebuild job, a helper script, and a primitive howto for
making it possible to re-use the same test infrastructure (MAVM) as used
in the main pipeline.

(the howto still has many missing docs, but this is not in scope here)

this is the first step for #136 

## Definition of done (v0.0.1)

- [x] Automated integration test (no user-facing code changes)
- [x] Integrity protection according to ADR-NNNN
- [x] Structured Logging and Monitoring for Lambda function according to ADR-NNNN
