### PR TITLE
fix(living-documentation): generate dashboard immediately after creation

### DIFF
--- a/templates/living-documentation.yaml
+++ b/templates/living-documentation.yaml
@@ -11,17 +11,10 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Events:
-        EmailHealth:
-          Type: CloudWatchEvent
+        Schedule:
+          Type: Schedule
           Properties:
-            Pattern:
-              detail-type:
-                - CloudWatch Alarm State Change
-              source:
-                - aws.cloudwatch
-              detail:
-                alarmName:
-                  - superwerker-RootMailReady
+            Schedule: rate(1 minute) # runs in Lambda free tier
 
       Handler: index.handler
       Policies:


### PR DESCRIPTION
The CW alarm event-driven invocation of the generator Lambda would be
too late since it triggers when the alarm is green.

So we move from event based trigger to scheduler every minute, which is
still covered by Lambda free tier and frees us from timing pains.

There might be still some gap between initial creation of the RootMail
alarm and the first call of the dashboard generator Lambda which would
result in exceptions in the generator Lambda. This was a deliberate
tradeoff.

fixes #153

## Definition of done (v0.0.1)

- [x] Automated integration test (dashboard creation has currently no tests and was out of scope in this bugfix)
- [x] Integrity protection according to ADR-NNNN (none needed)
- [x] Structured Logging and Monitoring for Lambda function according to ADR-NNNN (nothing changes)
