### PR TITLE
feat: rename SCP from "ServiceControlPolicy" into "superwerker"

### DIFF
--- a/templates/service-control-policies.yaml
+++ b/templates/service-control-policies.yaml
@@ -176,7 +176,7 @@ Resources:
             parameters = dict(
                 Content=Policy,
                 Description="superwerker - {}".format(LogicalResourceId),
-                Name=LogicalResourceId,
+                Name="superwerker",
             )
 
             policy_id = PhysicalResourceId

--- a/templates/service-control-policies.yaml
+++ b/templates/service-control-policies.yaml
@@ -22,7 +22,7 @@ Conditions:
 
 Resources:
 
-  ServiceControlPolicy:
+  SCPBaseline:
     Type: AWS::CloudFormation::CustomResource
     Properties:
       ServiceToken: !GetAtt SCPCustomResource.Arn


### PR DESCRIPTION
Current, the superwerker SCP is called `ServiceControlPolicy` as the logical ID in CloudFormation. This is confusing when using the AWS Organizations UI.

<img width="976" alt="Screenshot 2021-04-20 at 13 25 33" src="https://user-images.githubusercontent.com/248965/115388238-ecf01980-a1db-11eb-91b5-c88b1316c441.png">

I renamed it to `superwerker`

cc @tillkahlbrock 