### PR TITLE
fix: ServiceControlPolicies feature should not fail if neither SecurityHub nor Backup feature are enabled

### DIFF
--- a/templates/service-control-policies.yaml
+++ b/templates/service-control-policies.yaml
@@ -19,7 +19,7 @@ Parameters:
 Conditions:
   IncludeSecurityHub: !Equals [ !Ref IncludeSecurityHub, true ]
   IncludeBackup: !Equals [ !Ref IncludeBackup, true ]
-  SCPwithSecurityAndBackup: !And
+  RolloutSCPs: !And
     - !Equals [ !Ref IncludeSecurityHub, true ]
     - !Equals [ !Ref IncludeBackup, true ]
 
@@ -27,7 +27,7 @@ Resources:
 
   SCPBaseline:
     Type: AWS::CloudFormation::CustomResource
-    Condition: SCPwithSecurityAndBackup
+    Condition: RolloutSCPs
     Properties:
       ServiceToken: !GetAtt SCPCustomResource.Arn
       Policy: !Sub

--- a/templates/service-control-policies.yaml
+++ b/templates/service-control-policies.yaml
@@ -19,11 +19,15 @@ Parameters:
 Conditions:
   IncludeSecurityHub: !Equals [ !Ref IncludeSecurityHub, true ]
   IncludeBackup: !Equals [ !Ref IncludeBackup, true ]
+  SCPwithSecurityAndBackup: !And
+    - !Equals [ !Ref IncludeSecurityHub, true ]
+    - !Equals [ !Ref IncludeBackup, true ]
 
 Resources:
 
   SCPBaseline:
     Type: AWS::CloudFormation::CustomResource
+    Condition: SCPwithSecurityAndBackup
     Properties:
       ServiceToken: !GetAtt SCPCustomResource.Arn
       Policy: !Sub


### PR DESCRIPTION
Added condition to check if both features are set before creating resouce.
