### PR TITLE
tests: fix broken pipeline

### DIFF
--- a/templates/control-tower.yaml
+++ b/templates/control-tower.yaml
@@ -263,7 +263,6 @@ Resources:
       Environment:
         Variables:
           SIGNAL_URL: !Ref ControlTowerReadyHandle
-          CT_BUG_WORKSROUND_CANARY: !Ref ControlTowerBugWorkAroundCanary
       InlineCode: |-
         import boto3
         import json
@@ -307,12 +306,6 @@ Resources:
               ]
           )
 
-          # workaround for CT bug: trigger the `GetLandingZone` event once by reloading the dashboard
-          # otherwise enrolling new accounts via tge CT Account Factory would fail with
-          # "AWS Control Tower cannot create accounts until your landing zone is set up completely."
-          cws = boto3.client('synthetics')
-          cws.start_canary(Name=os.environ['CT_BUG_WORKSROUND_CANARY'])
-
       Policies:
         - Version: 2012-10-17
           Statement:
@@ -324,81 +317,6 @@ Resources:
             - Action: events:PutEvents
               Effect: Allow
               Resource: '*'
-            - Action:
-                - synthetics:StartCanary
-              Effect: Allow
-              Resource:
-                - !Sub arn:${AWS::Partition}:synthetics:${AWS::Region}:${AWS::AccountId}:canary:${ControlTowerBugWorkAroundCanary}
-
-  ControlTowerBugWorkAroundCanary:
-    Type: AWS::Synthetics::Canary
-    Properties:
-      Name: superwerker-ct-bug-wa
-      ArtifactS3Location: !Sub s3://${SetupControlTowerArtifactLocation}
-      ExecutionRoleArn: !GetAtt SetupControlTowerCanaryRole.Arn
-      RuntimeVersion: syn-nodejs-puppeteer-3.1
-      StartCanaryAfterCreation: false
-      RunConfig:
-        TimeoutInSeconds: 300
-      Schedule:
-        Expression: rate(0 minute) # manual start
-      Code:
-        Handler: pageLoadBlueprint.handler
-        Script: !Sub |
-          var synthetics = require('Synthetics');
-          const log = require('SyntheticsLogger');
-
-          const httpGet = url => {
-            const https = require('https');
-            return new Promise((resolve, reject) => {
-              https.get(url, res => {
-                res.setEncoding('utf8');
-                let body = '';
-                res.on('data', chunk => body += chunk);
-                res.on('end', () => resolve(body));
-              }).on('error', reject);
-            });
-          };
-
-          const flowBuilderBlueprint = async function () {
-            let page = await synthetics.getPage();
-
-            await synthetics.executeStep('consoleLogin', async function () {
-              const AWS = require("aws-sdk");
-
-              const federationEndpoint = 'https://signin.aws.amazon.com/federation';
-              const issuer = 'superwerker';
-              const destination = 'https://console.aws.amazon.com/';
-
-              let credentials = await AWS.config.credentialProvider.resolve((err, cred) => { return cred; }).resolvePromise()
-
-              const session = {
-                sessionId: credentials.accessKeyId,
-                sessionKey: credentials.secretAccessKey,
-                sessionToken: credentials.sessionToken
-              };
-
-              const encodedSession = encodeURIComponent(JSON.stringify(session));
-              const signinTokenUrl = `${!federationEndpoint}?Action=getSigninToken&SessionDuration=3600&Session=${!encodedSession}`;
-
-              const signinResponse = await httpGet(signinTokenUrl);
-
-              let consoleLoginUrl = `${!federationEndpoint}?Action=login&Issuer=${!issuer}&Destination=${!destination}&SigninToken=${!
-                JSON.parse(signinResponse).SigninToken
-              }`;
-
-              await page.goto(consoleLoginUrl, {waitUntil: ['load', 'networkidle0']});
-
-            });
-
-            await synthetics.executeStep('controltowerdashboard', async function () {
-              await page.goto("https://${AWS::Region}.console.aws.amazon.com/controltower/home/dashboard?region=${AWS::Region}", {waitUntil: ['load', 'networkidle0']});
-            });
-          };
-
-          exports.handler = async () => {
-            return await flowBuilderBlueprint();
-          };
 
 Metadata:
   SuperwerkerVersion: 0.0.0-DEVELOPMENT

--- a/tests/account-factory-wiring.yaml
+++ b/tests/account-factory-wiring.yaml
@@ -78,3 +78,121 @@ Resources:
       PortfolioId: !GetAtt ControlTowerServiceCatalogLookup.PortfolioId
       PrincipalARN: !Ref PipelineCloudformationRoleArn
       PrincipalType: IAM
+  
+  SetupControlTowerArtifactLocation:
+    Type: AWS::S3::Bucket
+    Properties:
+      LifecycleConfiguration:
+        Rules:
+          - ExpirationInDays: 1
+            Status: Enabled
+
+
+  SetupControlTowerArtifactLocationPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref SetupControlTowerArtifactLocation
+      PolicyDocument:
+        Statement:
+          - Effect: Allow
+            Action: '*'
+            Resource:
+              - !GetAtt SetupControlTowerArtifactLocation.Arn
+              - !Sub ${SetupControlTowerArtifactLocation.Arn}/*
+            Principal:
+              AWS: !GetAtt SetupControlTowerCanaryRole.Arn
+
+  SetupControlTowerCanaryRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+        - arn:aws:iam::aws:policy/AdministratorAccess # fixme: least privilege
+      Policies:
+        - PolicyName: AllowS3List
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - s3:ListAllMyBuckets
+                  - s3:GetBucketLocation
+                  - cloudwatch:PutMetricData
+                Resource: '*'
+
+  ControlTowerBugWorkAroundCanary:
+    Type: AWS::Synthetics::Canary
+    Properties:
+      Name: superwerker-ct-bug-wa
+      ArtifactS3Location: !Sub s3://${SetupControlTowerArtifactLocation}
+      ExecutionRoleArn: !GetAtt SetupControlTowerCanaryRole.Arn
+      RuntimeVersion: syn-nodejs-puppeteer-3.1
+      StartCanaryAfterCreation: false
+      RunConfig:
+        TimeoutInSeconds: 300
+      Schedule:
+        Expression: rate(0 minute) # manual start
+      Code:
+        Handler: pageLoadBlueprint.handler
+        Script: !Sub |
+          var synthetics = require('Synthetics');
+          const log = require('SyntheticsLogger');
+
+          const httpGet = url => {
+            const https = require('https');
+            return new Promise((resolve, reject) => {
+              https.get(url, res => {
+                res.setEncoding('utf8');
+                let body = '';
+                res.on('data', chunk => body += chunk);
+                res.on('end', () => resolve(body));
+              }).on('error', reject);
+            });
+          };
+
+          const flowBuilderBlueprint = async function () {
+            let page = await synthetics.getPage();
+
+            await synthetics.executeStep('consoleLogin', async function () {
+              const AWS = require("aws-sdk");
+
+              const federationEndpoint = 'https://signin.aws.amazon.com/federation';
+              const issuer = 'superwerker';
+              const destination = 'https://console.aws.amazon.com/';
+
+              let credentials = await AWS.config.credentialProvider.resolve((err, cred) => { return cred; }).resolvePromise()
+
+              const session = {
+                sessionId: credentials.accessKeyId,
+                sessionKey: credentials.secretAccessKey,
+                sessionToken: credentials.sessionToken
+              };
+
+              const encodedSession = encodeURIComponent(JSON.stringify(session));
+              const signinTokenUrl = `${!federationEndpoint}?Action=getSigninToken&SessionDuration=3600&Session=${!encodedSession}`;
+
+              const signinResponse = await httpGet(signinTokenUrl);
+
+              let consoleLoginUrl = `${!federationEndpoint}?Action=login&Issuer=${!issuer}&Destination=${!destination}&SigninToken=${!
+                JSON.parse(signinResponse).SigninToken
+              }`;
+
+              await page.goto(consoleLoginUrl, {waitUntil: ['load', 'networkidle0']});
+
+            });
+
+            await synthetics.executeStep('controltowerdashboard', async function () {
+              await page.goto("https://${AWS::Region}.console.aws.amazon.com/controltower/home/dashboard?region=${AWS::Region}", {waitUntil: ['load', 'networkidle0']});
+            });
+          };
+
+          exports.handler = async () => {
+            return await flowBuilderBlueprint();
+          };

--- a/tests/account-factory-wiring.yaml
+++ b/tests/account-factory-wiring.yaml
@@ -79,7 +79,7 @@ Resources:
       PrincipalARN: !Ref PipelineCloudformationRoleArn
       PrincipalType: IAM
   
-  SetupControlTowerArtifactLocation:
+  ControlTowerBugWorkAroundArtifactLocation:
     Type: AWS::S3::Bucket
     Properties:
       LifecycleConfiguration:
@@ -87,22 +87,21 @@ Resources:
           - ExpirationInDays: 1
             Status: Enabled
 
-
-  SetupControlTowerArtifactLocationPolicy:
+  ControlTowerBugWorkAroundArtifactLocationPolicy:
     Type: AWS::S3::BucketPolicy
     Properties:
-      Bucket: !Ref SetupControlTowerArtifactLocation
+      Bucket: !Ref ControlTowerBugWorkAroundArtifactLocation
       PolicyDocument:
         Statement:
           - Effect: Allow
             Action: '*'
             Resource:
-              - !GetAtt SetupControlTowerArtifactLocation.Arn
-              - !Sub ${SetupControlTowerArtifactLocation.Arn}/*
+              - !GetAtt ControlTowerBugWorkAroundArtifactLocation.Arn
+              - !Sub ${ControlTowerBugWorkAroundArtifactLocation.Arn}/*
             Principal:
-              AWS: !GetAtt SetupControlTowerCanaryRole.Arn
+              AWS: !GetAtt ControlTowerBugWorkAroundCanaryRole.Arn
 
-  SetupControlTowerCanaryRole:
+  ControlTowerBugWorkAroundCanaryRole:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
@@ -135,8 +134,8 @@ Resources:
     Type: AWS::Synthetics::Canary
     Properties:
       Name: superwerker-ct-bug-wa
-      ArtifactS3Location: !Sub s3://${SetupControlTowerArtifactLocation}
-      ExecutionRoleArn: !GetAtt SetupControlTowerCanaryRole.Arn
+      ArtifactS3Location: !Sub s3://${ControlTowerBugWorkAroundArtifactLocation}
+      ExecutionRoleArn: !GetAtt ControlTowerBugWorkAroundCanaryRole.Arn
       RuntimeVersion: syn-nodejs-puppeteer-3.1
       StartCanaryAfterCreation: true
       RunConfig:

--- a/tests/account-factory-wiring.yaml
+++ b/tests/account-factory-wiring.yaml
@@ -138,11 +138,11 @@ Resources:
       ArtifactS3Location: !Sub s3://${SetupControlTowerArtifactLocation}
       ExecutionRoleArn: !GetAtt SetupControlTowerCanaryRole.Arn
       RuntimeVersion: syn-nodejs-puppeteer-3.1
-      StartCanaryAfterCreation: false
+      StartCanaryAfterCreation: true
       RunConfig:
         TimeoutInSeconds: 300
       Schedule:
-        Expression: rate(0 minute) # manual start
+        Expression: rate(0 minute) # run once
       Code:
         Handler: pageLoadBlueprint.handler
         Script: !Sub |

--- a/tests/account-factory-wiring.yaml
+++ b/tests/account-factory-wiring.yaml
@@ -127,6 +127,10 @@ Resources:
                   - cloudwatch:PutMetricData
                 Resource: '*'
 
+  # workaround for CT bug: trigger the `GetLandingZone` event once by reloading the dashboard
+  # otherwise enrolling new accounts via tge CT Account Factory would fail with
+  # "AWS Control Tower cannot create accounts until your landing zone is set up completely."
+
   ControlTowerBugWorkAroundCanary:
     Type: AWS::Synthetics::Canary
     Properties:


### PR DESCRIPTION
It appears that the setup control tower event is triggered before the landing zone is completed, therefore the workaround starts too early and the subaccount creation for the tests fails. We are trying to prevent the control tower workaround from triggering too early by moving the workaround code into the tests. 