### PR TITLE
docs: remove misleading links to non existant ADRs in PR template checklist items

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,5 +1,4 @@
-## Definition of done (v0.0.1)
+## Definition of done (v0.0.2)
 
 - [ ] Automated integration test
-- [ ] Integrity protection according to ADR-NNNN
-- [ ] Structured Logging and Monitoring for Lambda function according to ADR-NNNN
+


### PR DESCRIPTION

We don't have ADRs for logging and integrity protection, so remove the misleading checklist items.

