### PR TITLE
tests: avoid broken cleanup due to nonexisting git references

### DIFF
--- a/tests/buildspec.yaml
+++ b/tests/buildspec.yaml
@@ -87,4 +87,4 @@ phases:
 
       # call sub-account closing and stack cleanup
       # when called by codepipeline there is no git source version info, so we ommit source version so codebuild uses the main branch
-      - aws codebuild start-build --project-name ${SUPERWERKER_CLEANUP_PROJECT_NAME} --environment-variables-override name=AWS_CROSS_ACCOUNT_ROLE_ARN,value=${aws_cross_account_role_arn} name=SUPERWERKER_REGION,value=${SUPERWERKER_REGION} name=AWS_ACCOUNT_ID,value=${aws_account_id}  $([[ $CODEBUILD_INITIATOR != "codepipeline/"* ]] && echo --source-version $CODEBUILD_RESOLVED_SOURCE_VERSION)
+      - aws codebuild start-build --project-name ${SUPERWERKER_CLEANUP_PROJECT_NAME} --environment-variables-override name=AWS_CROSS_ACCOUNT_ROLE_ARN,value=${aws_cross_account_role_arn} name=SUPERWERKER_REGION,value=${SUPERWERKER_REGION} name=AWS_ACCOUNT_ID,value=${aws_account_id}


### PR DESCRIPTION
Sometimes, in Pull Requests, a branch reference might be already deleted
on GitHub, probably due to force pushes on feature branches. Then the
cleanup CodeBuild fails with

```
reference not found for primary source and source version ...
```

To work around this, always call the cleanup CodeBuild from the default
`main` branch. This change will result in the `buildspec-cleanup.yaml`
always being used from the `main` branch, not a feature branch.

## Definition of done (v0.0.2)

- [x] Automated integration test

