### PR TITLE
fix: make backup stack more resilient by using awsapilib instead of CWS canaries

### DIFF
--- a/templates/backup.yaml
+++ b/templates/backup.yaml
@@ -104,7 +104,7 @@ Resources:
 
   BackupResources:
     Type: AWS::CloudFormation::StackSet
-    DependsOn: EnableCloudFormationStacksetsOrgAccessReadyWaitCondition
+    DependsOn: EnableCloudFormationStacksetsOrgAccessCustomResource
     Properties:
       StackSetName: superwerker-backup
       PermissionModel: SERVICE_MANAGED
@@ -426,88 +426,78 @@ Resources:
 
             cfnresponse.send(event, context, cfnresponse.SUCCESS, data, id)
 
-  EnableCloudFormationStacksetsOrgAccess:
-    Type: AWS::Synthetics::Canary
-    DependsOn: CfnStackSetsReadyEnablePermission # make sure the Lambda which handles the wait condition is entirely ready before enabling Cloudformation Org access. This includes Lambda event+permission have to be ready.
-    Metadata:
-      cfn-lint:
-        config:
-          ignore_checks:
-          - E1029
+  EnableCloudFormationStacksetsOrgAccessCustomResource:
+    Type: AWS::CloudFormation::CustomResource
     Properties:
-      Name: superwerker-cfn-org
-      ArtifactS3Location: !Sub s3://${EnableCloudFormationStacksetsOrgAccessArtifacts}
-      ExecutionRoleArn: !GetAtt EnableCloudFormationStacksetsOrgAccessRole.Arn
-      RuntimeVersion: syn-nodejs-puppeteer-3.1
-      StartCanaryAfterCreation: true
-      RunConfig:
-        TimeoutInSeconds: 300
-        EnvironmentVariables:
-          REGION: !Ref AWS::Region
-      Schedule:
-        Expression: rate(0 minute) # manual start
-      Code:
-        Handler: pageLoadBlueprint.handler
-        Script: |
-          var synthetics = require('Synthetics');
-          const log = require('SyntheticsLogger');
+      ServiceToken: !GetAtt EnableCloudFormationStacksetsOrgAccessCustomResourceFunction.Arn
 
-          const httpGet = url => {
-            const https = require('https');
-            return new Promise((resolve, reject) => {
-              https.get(url, res => {
-                res.setEncoding('utf8');
-                let body = '';
-                res.on('data', chunk => body += chunk);
-                res.on('end', () => resolve(body));
-              }).on('error', reject);
-            });
-          };
+  EnableCloudFormationStacksetsOrgAccessCustomResourceFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: index.handler
+      Runtime: python3.7
+      Timeout: 60
+      Role: !GetAtt EnableCloudFormationStacksetsOrgAccessCustomResourceRole.Arn # provide explicit role to avoid circular dependency with AwsApiLibRole
+      Policies:
+        - Version: 2012-10-17
+          Statement:
+            - Effect: Allow
+              Action: sts:AssumeRole
+              Resource: !GetAtt AwsApiLibRole.Arn
+      Environment:
+        Variables:
+          AWSAPILIB_ROLE_ARN: !GetAtt AwsApiLibRole.Arn
+      InlineCode: |
+        import boto3
+        import os
+        import cfnresponse
+        import sys
+        import subprocess
 
-          const flowBuilderBlueprint = async function () {
-            let page = await synthetics.getPage();
+        # load awsapilib in-process as long as we have no strategy for bundling assets
+        sys.path.insert(1, '/tmp/packages')
+        subprocess.check_call([sys.executable, "-m", "pip", "install", '--target', '/tmp/packages', 'awsapilib==0.10.1'])
+        import awsapilib
+        from awsapilib import Cloudformation
 
-            await synthetics.executeStep('consoleLogin', async function () {
-              const AWS = require("aws-sdk");
+        CREATE = 'Create'
+        DELETE = 'Delete'
+        UPDATE = 'Update'
 
-              const federationEndpoint = 'https://signin.aws.amazon.com/federation';
-              const issuer = 'superwerker';
-              const destination = 'https://console.aws.amazon.com/';
+        def exception_handling(function):
+            def catch(event, context):
+                try:
+                    function(event, context)
+                except Exception as e:
+                    print(e)
+                    print(event)
+                    cfnresponse.send(event, context, cfnresponse.FAILED, {})
 
-              let credentials = await AWS.config.credentialProvider.resolve((err, cred) => { return cred; }).resolvePromise()
+            return catch
 
-              const session = {
-                sessionId: credentials.accessKeyId,
-                sessionKey: credentials.secretAccessKey,
-                sessionToken: credentials.sessionToken
-              };
+        @exception_handling
+        def handler(event, context):
+            RequestType = event["RequestType"]
+            Properties = event["ResourceProperties"]
+            LogicalResourceId = event["LogicalResourceId"]
+            PhysicalResourceId = event.get("PhysicalResourceId")
 
-              const encodedSession = encodeURIComponent(JSON.stringify(session));
-              const signinTokenUrl = `${federationEndpoint}?Action=getSigninToken&SessionDuration=3600&Session=${encodedSession}`;
+            print('RequestType: {}'.format(RequestType))
+            print('PhysicalResourceId: {}'.format(PhysicalResourceId))
+            print('LogicalResourceId: {}'.format(LogicalResourceId))
 
-              const signinResponse = await httpGet(signinTokenUrl);
+            id = PhysicalResourceId
 
-              let consoleLoginUrl = `${federationEndpoint}?Action=login&Issuer=${issuer}&Destination=${destination}&SigninToken=${
-                JSON.parse(signinResponse).SigninToken
-              }`;
+            data = {}
 
-              await page.goto(consoleLoginUrl, {waitUntil: ['load', 'networkidle0']});
+            cf = Cloudformation(os.environ['AWSAPILIB_ROLE_ARN'])
 
-            });
+            if RequestType == CREATE:
+                cf.stacksets.enable_organizations_trusted_access()
 
-            await synthetics.executeStep('stacksets', async function () {
-              await page.goto(`https://${process.env.REGION}.console.aws.amazon.com/cloudformation/home?region=${process.env.REGION}#/stacksets`, {waitUntil: ['load', 'networkidle0']});
-              await page.waitFor(10000);
-              await page.click("#console-app > div > awsui-app-layout > div > main > div > div.awsui-app-layout__content--scrollable > div:nth-child(2) > span > div > awsui-alert > div > div.awsui-alert-body > div > div > span > div > div > div.col-s-3 > awsui-button > button");
-              await page.waitFor(20000);
-            });
-          };
+            cfnresponse.send(event, context, cfnresponse.SUCCESS, data, id)
 
-          exports.handler = async () => {
-            return await flowBuilderBlueprint();
-          };
-
-  EnableCloudFormationStacksetsOrgAccessRole:
+  EnableCloudFormationStacksetsOrgAccessCustomResourceRole:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
@@ -518,62 +508,41 @@ Resources:
               Service: lambda.amazonaws.com
             Action: sts:AssumeRole
       ManagedPolicyArns:
-        - !Sub arn:${AWS::Partition}:iam::aws:policy/AdministratorAccess
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
 
-  EnableCloudFormationStacksetsOrgAccessArtifacts:
-    Type: AWS::S3::Bucket
+  EnableCloudFormationStacksetsOrgAccessCustomResourceRolePolicy:
+    Type: AWS::IAM::Policy
     Properties:
-      LifecycleConfiguration:
-        Rules:
-          - ExpirationInDays: 1
-            Status: Enabled
+      PolicyDocument:
+        Statement:
+          - Effect: Allow
+            Action: sts:AssumeRole
+            Resource: !GetAtt AwsApiLibRole.Arn
+        Version: 2012-10-17
+      PolicyName: !Sub ${EnableCloudFormationStacksetsOrgAccessCustomResourceRole}Policy
+      Roles:
+        - !Ref EnableCloudFormationStacksetsOrgAccessCustomResourceRole
 
-  EnableCloudFormationStacksetsOrgAccessReadyHandle:
-    Type: AWS::CloudFormation::WaitConditionHandle
-
-  EnableCloudFormationStacksetsOrgAccessReadyWaitCondition:
-    Type: AWS::CloudFormation::WaitCondition
+  AwsApiLibRole:
+    Type: AWS::IAM::Role
     Properties:
-      Handle: !Ref EnableCloudFormationStacksetsOrgAccessReadyHandle
-      Timeout: '1200'
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !GetAtt EnableCloudFormationStacksetsOrgAccessCustomResourceRole.Arn
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AdministratorAccess
 
-  CfnStackSetsReady:
-    Type: AWS::Serverless::Function
-    Properties:
-      Events:
-        Enable:
-          Type: CloudWatchEvent
-          Properties:
-            Pattern:
-              source:
-                - aws.cloudformation
-              detail-type:
-                - AWS API Call via CloudTrail
-              detail:
-                eventName:
-                  - EnableOrganizationsAccess
-                eventSource:
-                  - cloudformation.amazonaws.com
-      Handler: index.handler
-      Runtime: python3.7
-      Environment:
-        Variables:
-          SIGNAL_URL: !Ref EnableCloudFormationStacksetsOrgAccessReadyHandle
-      InlineCode: |-
-        import json
-        import urllib3
-        import os
-
-        def handler(event, context):
-          encoded_body = json.dumps({
-              "Status": "SUCCESS",
-              "Reason": "CloudFormation Managed StackSets Organizations ready",
-              "UniqueId": "doesthisreallyhavetobeunique",
-              "Data": "CloudFormation Managed StackSets Organizations ready"
-          })
-          http = urllib3.PoolManager()
-          http.request('PUT', os.environ['SIGNAL_URL'], body=encoded_body)
-
+#  EnableCloudFormationStacksetsOrgAccessArtifacts: # left for backwards compatibility
+#    Type: AWS::S3::Bucket
+#    Properties:
+#      LifecycleConfiguration:
+#        Rules:
+#          - ExpirationInDays: 1
+#            Status: Enabled
 
   # Proudly found elsewhere and partially copied from:
   # https://github.com/theserverlessway/aws-baseline


### PR DESCRIPTION
 - more robust against UI changes
 - works also when CFN Service_Managed Stack Sets are already enabled

## Definition of done (v0.0.2)

- [x] Automated integration test

