### PR TITLE
Extend update steps in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ We plan to roll-out releases via GitHub releases. The update is then deployed vi
 1. Choose `Replace current template`
 1. For `Amazon S3 URL`, copy the link to the latest version of the template e.g. "https://superwerker-releases.s3.amazonaws.com/0.13.0/templates/superwerker.template.yaml", the latest version number can be found here: [Github Releases](https://github.com/superwerker/superwerker/releases)
 1. Click `Next`
+1. Ensure the parameter `QSS3BucketName` is set to `superwerker-releases`
 1. Change the parameter `QSS3KeyPrefix` to the current version number e.g. `0.13.0/`
 1. Click `Next`
 1. Click `Next` again


### PR DESCRIPTION
I ran into an issue when updating from `0.12.x` to `0.13.x` because we renamed the deployment/release bucket. The existing parameters had `QSS3BucketName` set to `superwerker-deployments` and at some point we changed the bucket to `superwerker-releases`.

With the incorrect bucket name, CloudFormation failed to update the stack:

```
S3 error: Access Denied
For more information check http://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html
```