### PR TITLE
feat: expose configured domain as output

### DIFF
--- a/templates/superwerker.template.yaml
+++ b/templates/superwerker.template.yaml
@@ -333,3 +333,6 @@ Outputs:
   CloudWatchDashboard:
     Description: See the CloudWatch superwerker dashboard for post-deployment steps
     Value: https://console.aws.amazon.com/cloudwatch/home#dashboards:name=superwerker
+  Domain:
+    Description: Domain used for RootMail feature
+    Value: !Sub '${Subdomain}.${Domain}'


### PR DESCRIPTION
I want to retrieve the configured domain and subdomain of a `superwerker` installation. Currently, I need to retrieve the Stack's parameters first and then concat the provided values. If there is an output with the provided information, this gets way easier. 