### PR TITLE
feat: expose version as output

### DIFF
--- a/scripts/versioning.sh
+++ b/scripts/versioning.sh
@@ -1,2 +1,2 @@
 VERSION=${1:-0.0.0-DEVELOPMENT}
-sed -i "s/0.0.0-DEVELOPMENT/${VERSION}/" templates/*.yaml
+sed -i "s/0.0.0-DEVELOPMENT/${VERSION}/g" templates/*.yaml

--- a/templates/superwerker.template.yaml
+++ b/templates/superwerker.template.yaml
@@ -333,3 +333,6 @@ Outputs:
   CloudWatchDashboard:
     Description: See the CloudWatch superwerker dashboard for post-deployment steps
     Value: https://console.aws.amazon.com/cloudwatch/home#dashboards:name=superwerker
+  Version:
+    Description: Version of superwerker
+    Value: 0.0.0-DEVELOPMENT


### PR DESCRIPTION
I want to retrieve the version of a superwerker installation. Currently, I need to retrieve the Stack's template first and then extract the version from the metadata. Having an output with the version makes things easier.

Additionally, I extended the regular expression (used in `versioning.sh`) with `g` as the global modifier.