### PR TITLE
Configure DeletionPolicy and UpdateReplacePolicy for OrganizationConformancePackBucket

### DIFF
--- a/templates/backup.yaml
+++ b/templates/backup.yaml
@@ -78,6 +78,7 @@ Resources:
 
   OrganizationConformancePackBucket:
     Type: AWS::S3::Bucket
+    DeletionPolicy: Retain
     Properties:
       BucketName: !Sub awsconfigconforms-${AWS::AccountId}
 

--- a/templates/backup.yaml
+++ b/templates/backup.yaml
@@ -79,6 +79,7 @@ Resources:
   OrganizationConformancePackBucket:
     Type: AWS::S3::Bucket
     DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       BucketName: !Sub awsconfigconforms-${AWS::AccountId}
 


### PR DESCRIPTION
As the rollout of the automated backups feature may fail, the bucket storing conformance packs should have `retain` as deletion policy. Otherwise, the rollback fails as well.

refs #261