### PR TITLE
Close stale issues automatically

### DIFF
--- a/.github/workflows/stale-issues-and-prs.yml
+++ b/.github/workflows/stale-issues-and-prs.yml
@@ -1,0 +1,17 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v5
+        with:
+          days-before-stale: 60
+          days-before-close: 5
+          stale-issue-message: 'This issue is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
+          exempt-issue-labels: someday
+          exempt-all-milestones: true
+          debug-only: true


### PR DESCRIPTION
Close stale issues after 60 days and 5 days of inactivity. Issues labeled with "someday" or issues associated with a milestone won't be touched. Only run in dry run mode for now, check if results are OK.

