### PR TITLE
chore: change to latest syn-nodejs-puppeteer-3.8

### DIFF
--- a/tests/account-factory-wiring.yaml
+++ b/tests/account-factory-wiring.yaml
@@ -136,7 +136,7 @@ Resources:
       Name: superwerker-ct-bug-wa
       ArtifactS3Location: !Sub s3://${ControlTowerBugWorkAroundArtifactLocation}
       ExecutionRoleArn: !GetAtt ControlTowerBugWorkAroundCanaryRole.Arn
-      RuntimeVersion: syn-nodejs-puppeteer-3.1
+      RuntimeVersion: syn-nodejs-puppeteer-3.8
       StartCanaryAfterCreation: true
       RunConfig:
         TimeoutInSeconds: 300


### PR DESCRIPTION
## Definition of done (v0.0.2)

- [X] Automated integration test

#336: Fixed latest version of `syn-nodejs-pupeteer` to 3.7
