### PR TITLE
chore: Remove obsolete Quickstart S3 prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,6 @@ We plan to roll-out releases via GitHub releases. The update is then deployed vi
 1. Choose `Replace current template`
 1. For `Amazon S3 URL`, copy the link to the latest version of the template e.g. "https://superwerker-releases.s3.amazonaws.com/0.13.0/templates/superwerker.template.yaml", the latest version number can be found here: [Github Releases](https://github.com/superwerker/superwerker/releases)
 1. Click `Next`
-1. Ensure the parameter `QSS3BucketName` is set to `superwerker-releases`
-1. Change the parameter `QSS3KeyPrefix` to the current version number e.g. `0.13.0/`
 1. Click `Next`
 1. Click `Next` again
 1. Tick the boxes acknowledging that CloudFormation might create IAM resources such as Roles and Policies

--- a/cdk/src/stacks/superwerker.ts
+++ b/cdk/src/stacks/superwerker.ts
@@ -38,11 +38,6 @@ export class SuperwerkerStack extends Stack {
       },
     };
 
-    // keep these around so we can still deploy the stack with the same parameters
-    new CfnParameter(this, 'QSS3BucketName', { default: '' });
-    new CfnParameter(this, 'QSS3BucketRegion', { default: '' });
-    new CfnParameter(this, 'QSS3KeyPrefix', { default: '' });
-
     const domain = new CfnParameter(this, 'Domain', {
       type: 'String',
       description: 'Domain used for root mail feature. Please see https://github.com/superwerker/superwerker/blob/main/README.md#technical-faq for more information',

--- a/tests/buildspec.yaml
+++ b/tests/buildspec.yaml
@@ -68,9 +68,6 @@ phases:
           aws --profile test_account_iam_user_access --region ${SUPERWERKER_REGION} cloudformation create-stack --stack-name superwerker --template-url ${previously_released_template_url} \
               --parameters ParameterKey=Domain,ParameterValue=${ROOT_MAIL_DOMAIN} \
                            ParameterKey=Subdomain,ParameterValue=${aws_account_id} \
-                           ParameterKey=QSS3BucketName,ParameterValue=superwerker-releases \
-                           ParameterKey=QSS3BucketRegion,ParameterValue=${TEMPLATE_REGION} \
-                           ParameterKey=QSS3KeyPrefix,ParameterValue="${latest_release}/" \
                            ParameterKey=NotificationsMail,ParameterValue=root+notifications@${aws_account_id}.${ROOT_MAIL_DOMAIN} \
                --capabilities CAPABILITY_AUTO_EXPAND CAPABILITY_IAM --disable-rollback
           sleep 10 # work around race condition when multiple aws cli processes want to create the cache: [Errno 17] File exists: '/root/.aws/cli/cache'

--- a/tests/update-test-env.sh
+++ b/tests/update-test-env.sh
@@ -17,4 +17,4 @@ template_prefix=${git_branch}/
 
 aws --profile ${SOURCE_PROFILE} s3 sync ${SCRIPT_DIR}/../templates s3://superwerker-deployment/${git_branch}/templates
 
-aws --profile test_account_${AWS_ACCOUNT_ID} --region ${superwerker_region} cloudformation deploy --stack-name superwerker --template-file ${SCRIPT_DIR}/../templates/superwerker.template.yaml --parameter-overrides QSS3BucketName=${template_bucket_name} QSS3BucketRegion=${template_region} QSS3KeyPrefix=${template_prefix} --capabilities CAPABILITY_AUTO_EXPAND CAPABILITY_IAM --no-fail-on-empty-changeset
+aws --profile test_account_${AWS_ACCOUNT_ID} --region ${superwerker_region} cloudformation deploy --stack-name superwerker --template-file ${SCRIPT_DIR}/../templates/superwerker.template.yaml --capabilities CAPABILITY_AUTO_EXPAND CAPABILITY_IAM --no-fail-on-empty-changeset


### PR DESCRIPTION
We don't need these anymore because CDK assets solve the multiple stacks problem for us.
Also this will fix [this error](https://github.com/aws-quickstart/quickstart-superwerker/pull/37/checks?check_run_id=11058790327).