### PR TITLE
fix: add boto3 to requirements.txt

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,4 @@
+boto3
 retrying
 pytest
 pytest-timeout

--- a/tests/requirements_local.txt
+++ b/tests/requirements_local.txt
@@ -1,2 +1,0 @@
--r requirements.txt
-boto3


### PR DESCRIPTION
using virtualenv means we have to install all dependencies into the virtualenv, including boto3.