### PR TITLE
ci: increase AWS session duration to 2 hours for codebuild run

### DIFF
--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -40,6 +40,7 @@ jobs:
         with:
           aws-region: eu-west-1
           role-to-assume: arn:aws:iam::824014778649:role/gh-actions-superwerker-test
+          role-duration-seconds: 7200      # Set the session duration to 2 hours as codebuild takes very long
       - name: Run CodeBuild
         uses: aws-actions/aws-codebuild-run-build@v1
         with:


### PR DESCRIPTION
This PR increases the codebuild session duration 2 hours, as it tends to run relatively long. This way, gh-actions will not receive a timeout during the build, hopefully.
See also: https://github.com/aws-actions/configure-aws-credentials#assuming-a-role