### PR TITLE
chore: group aws-sdk dependencies in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,10 @@ updates:
     directory: "cdk/"
     schedule:
       interval: "weekly"
+    groups:
+      aws-sdk:
+        patterns:
+          - "@aws-sdk/*"
   - package-ecosystem: "pip"
     directory: "/"
     schedule:


### PR DESCRIPTION
This PR defines a group in the `dependabot` configuration intended to upgrade all `@aws-sdk/*` dependencies together. The intention is to avoid `dependabot` creating many small pull requests for `aws-sdk` components that should all match the same version number.