### PR TITLE
chore: group development dependencies in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,7 @@ updates:
           - "@aws-sdk/*"
       development:
         dependency-type: "development"
+    open-pull-requests-limit: 10
   - package-ecosystem: "pip"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,8 @@ updates:
       aws-sdk:
         patterns:
           - "@aws-sdk/*"
+      development:
+        dependency-type: "development"
   - package-ecosystem: "pip"
     directory: "/"
     schedule:


### PR DESCRIPTION
This PR groups development dependencies in dependabot in order to consolidate generated PRs for lower risk dev upgrades.

Also experimentally updates the number of PRs dependabot is allowed to open to 10 to avoid errors in the dependabot logs:

https://github.com/superwerker/superwerker/network/updates