### PR TITLE
chore: target only minor and patch version updates for dependabot development group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,9 @@ updates:
           - "@aws-sdk/*"
       development:
         dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
     open-pull-requests-limit: 10
   - package-ecosystem: "pip"
     directory: "/"


### PR DESCRIPTION
This PR targets only `minor` and `patch` updates according to semantic versioning `major.minor.patch` for the development dependencies when managed by dependabot.