### PR TITLE
Remove redundant if, cfn-lint finding

### DIFF
--- a/templates/service-control-policies.yaml
+++ b/templates/service-control-policies.yaml
@@ -29,11 +29,7 @@ Resources:
                   ${Statements}
               ]
           }
-        - Statements: !Join
-            - ","
-            - - !If
-                - IncludeBackup
-                - !Sub |
+        - Statements: !Sub |
                   {
                       "Condition": {
                           "ArnNotLike": {
@@ -60,7 +56,6 @@ Resources:
                       "Effect": "Deny",
                       "Sid": "SWProtectBackup"
                   }
-                - !Ref AWS::NoValue
       Attach: true
 
   SCPCustomResource:


### PR DESCRIPTION
cfn-lint failed with
`W1028 ['Fn::If', 2] is not reachable. When setting condition 'IncludeBackup' to False from current status True
templates/service-control-policies.yaml:63:19`
because of a redundant If.
This patch removes the redundant condition