### PR TITLE
fix: Remove redundant if, cfn-lint finding

### DIFF
--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -36,6 +36,7 @@ on:
 # the defaults
 env:
   SUPERWERKER_REGION: eu-central-1
+  AWS_DEFAULT_REGION: eu-central-1
   UPDATE_FROM_LATEST_RELEASE: false
 jobs:
   pr-conventions:

--- a/templates/service-control-policies.yaml
+++ b/templates/service-control-policies.yaml
@@ -29,11 +29,7 @@ Resources:
                   ${Statements}
               ]
           }
-        - Statements: !Join
-            - ","
-            - - !If
-                - IncludeBackup
-                - !Sub |
+        - Statements: !Sub |
                   {
                       "Condition": {
                           "ArnNotLike": {
@@ -60,7 +56,6 @@ Resources:
                       "Effect": "Deny",
                       "Sid": "SWProtectBackup"
                   }
-                - !Ref AWS::NoValue
       Attach: true
 
   SCPCustomResource:


### PR DESCRIPTION
cnf lint reported: 
`W1028 ['Fn::If', 2] is not reachable. When setting condition 'IncludeBackup' to False from current status True
templates/service-control-policies.yaml:63:19`
due to a the extra If statement inside the SCPBaseline. Because the resource only instantiates if the **IncludeBackup** condition is true, the extra condition inside the Statements is obsolete. 