### PR TITLE
feat: get rid of long term AWS credentials

### DIFF
--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -5,6 +5,10 @@ on:
   push:
     branches: ['*']
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -27,12 +31,12 @@ jobs:
       run: scripts/versioning.sh ${{ steps.extract_branch.outputs.branch }}
       id: version_templates
 
-    - uses: shallwefootball/s3-upload-action@master
-      name: Upload S3
-      id: S3
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v4
       with:
-        aws_key_id: ${{ secrets.AWS_ACCESS_KEY }}
-        aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY}}
-        aws_bucket: ${{ secrets.AWS_BUCKET_NAME}}
-        source_dir: templates/
-        destination_dir: ${{ steps.extract_branch.outputs.branch }}/templates/
+        role-to-assume: ${{ vars.AWS_DEPLOY_ROLE }}
+        aws-region: ${{ vars.AWS_REGION }}
+
+    - name: Upload s3
+      shell: bash
+      run: aws s3 sync templates/ s3://${{ vars.AWS_S3_BUCKET }}/${{ steps.extract_branch.outputs.branch }}/templates/ --delete

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,6 @@
 name: Lint CloudFormation Templates
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   lint:


### PR DESCRIPTION
Authenticate to AWS by assuming a role instead of storing long term credentials for deployment.
This requires an OIDC and a role in the target AWS account. Also, the AWS_REGION and AWS_DEPLOY_ROLE environment variables need to be set.